### PR TITLE
Do not load Rubygems unless needed

### DIFF
--- a/toys-core/.rubocop.yml
+++ b/toys-core/.rubocop.yml
@@ -67,6 +67,9 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/Next:
   Enabled: false
+Style/NumericLiterals:
+  Exclude:
+    - "lib/toys/compat.rb"
 Style/Semicolon:
   Enabled: false
 Style/StringLiterals:

--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 ;
 
+require "rbconfig"
 require "logger"
 require "toys/completion"
 

--- a/toys-core/lib/toys/compat.rb
+++ b/toys-core/lib/toys/compat.rb
@@ -21,6 +21,8 @@
 # IN THE SOFTWARE.
 ;
 
+require "rbconfig"
+
 module Toys
   ##
   # Compatibility wrappers for older Ruby versions.
@@ -42,9 +44,16 @@ module Toys
 
     # @private
     def self.supports_suggestions?
-      require "rubygems"
-      require "did_you_mean" rescue nil # rubocop:disable Style/RescueModifier
-      defined?(::DidYouMean::SpellChecker)
+      unless defined?(@supports_suggestions)
+        require "rubygems"
+        begin
+          require "did_you_mean"
+          @supports_suggestions = defined?(::DidYouMean::SpellChecker)
+        rescue ::LoadError
+          @supports_suggestions = false
+        end
+      end
+      @supports_suggestions
     end
 
     # @private

--- a/toys-core/lib/toys/compat.rb
+++ b/toys-core/lib/toys/compat.rb
@@ -27,51 +27,44 @@ module Toys
   # @private
   #
   module Compat
-    ## @private
-    CURRENT_VERSION = ::Gem::Version.new(::RUBY_VERSION)
+    parts = ::RUBY_VERSION.split(".")
+    ruby_version = parts[0].to_i * 10000 + parts[1].to_i * 100 + parts[2].to_i
 
-    ## @private
-    def self.check_minimum_version(version)
-      CURRENT_VERSION >= ::Gem::Version.new(version)
-    end
-
-    ## @private
+    # @private
     def self.jruby?
       ::RUBY_PLATFORM == "java"
     end
 
-    ## @private
+    # @private
     def self.allow_fork?
-      !jruby? && RbConfig::CONFIG["host_os"] !~ /mswin/
+      !jruby? && ::RbConfig::CONFIG["host_os"] !~ /mswin/
     end
 
-    ## @private
+    # @private
     def self.supports_suggestions?
+      require "rubygems"
+      require "did_you_mean" rescue nil # rubocop:disable Style/RescueModifier
       defined?(::DidYouMean::SpellChecker)
     end
 
-    # Check for DidYouMean::SpellChecker
-    if supports_suggestions?
-      ## @private
-      def self.suggestions(word, list)
+    # @private
+    def self.suggestions(word, list)
+      if supports_suggestions?
         ::DidYouMean::SpellChecker.new(dictionary: list).correct(word)
-      end
-    else
-      ## @private
-      def self.suggestions(_word, _list)
+      else
         []
       end
     end
 
     # In Ruby < 2.4, some objects such as nil cannot be cloned.
-    if check_minimum_version("2.4.0")
-      ## @private
+    if ruby_version >= 20400
+      # @private
       def self.merge_clones(hash, orig)
         orig.each { |k, v| hash[k] = v.clone }
         hash
       end
     else
-      ## @private
+      # @private
       def self.merge_clones(hash, orig)
         orig.each do |k, v|
           hash[k] =
@@ -86,13 +79,13 @@ module Toys
     end
 
     # The :base argument to Dir.glob requires Ruby 2.5 or later.
-    if check_minimum_version("2.5.0")
-      ## @private
+    if ruby_version >= 20500
+      # @private
       def self.glob_in_dir(glob, dir)
         ::Dir.glob(glob, base: dir)
       end
     else
-      ## @private
+      # @private
       def self.glob_in_dir(glob, dir)
         ::Dir.chdir(dir) { ::Dir.glob(glob) }
       end
@@ -100,13 +93,13 @@ module Toys
 
     # Due to a bug in Ruby < 2.7, passing an empty **kwargs splat to
     # initialize will fail if there are no formal keyword args.
-    if check_minimum_version("2.7.0")
-      ## @private
+    if ruby_version >= 20700
+      # @private
       def self.instantiate(klass, args, kwargs, block)
         klass.new(*args, **kwargs, &block)
       end
     else
-      ## @private
+      # @private
       def self.instantiate(klass, args, kwargs, block)
         formals = klass.instance_method(:initialize).parameters
         if kwargs.empty? && formals.all? { |arg| arg.first != :key && arg.first != :keyrest }

--- a/toys-core/lib/toys/context.rb
+++ b/toys-core/lib/toys/context.rb
@@ -21,8 +21,6 @@
 # IN THE SOFTWARE.
 ;
 
-require "logger"
-
 module Toys
   ##
   # This is the base class for tool execution. It represents `self` when your

--- a/toys-core/lib/toys/dsl/tool.rb
+++ b/toys-core/lib/toys/dsl/tool.rb
@@ -1647,6 +1647,7 @@ module Toys
       # @return [Boolean] whether or not the requirements are satisfied
       #
       def toys_version?(*requirements)
+        require "rubygems"
         version = ::Gem::Version.new(Core::VERSION)
         requirement = ::Gem::Requirement.new(*requirements)
         requirement.satisfied_by?(version)
@@ -1662,6 +1663,7 @@ module Toys
       #     satisfy the requirements.
       #
       def toys_version!(*requirements)
+        require "rubygems"
         version = ::Gem::Version.new(Core::VERSION)
         requirement = ::Gem::Requirement.new(*requirements)
         unless requirement.satisfied_by?(version)

--- a/toys-core/lib/toys/utils/exec.rb
+++ b/toys-core/lib/toys/utils/exec.rb
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 ;
 
+require "rbconfig"
 require "logger"
 require "shellwords"
 

--- a/toys-core/lib/toys/utils/gems.rb
+++ b/toys-core/lib/toys/utils/gems.rb
@@ -22,6 +22,7 @@
 ;
 
 require "monitor"
+require "rubygems"
 
 module Toys
   module Utils

--- a/toys-core/test/test_cli.rb
+++ b/toys-core/test/test_cli.rb
@@ -23,6 +23,8 @@
 
 require "helper"
 
+require "toys/utils/exec"
+
 describe Toys::CLI do
   let(:logger_io) { ::StringIO.new }
   let(:logger) {

--- a/toys-core/toys-core.gemspec
+++ b/toys-core/toys-core.gemspec
@@ -43,6 +43,7 @@ require "toys/core"
   spec.required_ruby_version = ">= 2.3.0"
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "did_you_mean", "~> 1.0"
   spec.add_development_dependency "highline", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-focus", "~> 1.1"

--- a/toys-dev
+++ b/toys-dev
@@ -1,5 +1,4 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
+#!/bin/sh
 
 # Copyright 2019 Daniel Azuma
 #
@@ -20,9 +19,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-;
 
-::ENV["TOYS_DEV"] = "true"
-::ENV["TOYS_CORE_LIB_PATH"] = ::File.absolute_path(::File.join(__dir__, "toys-core", "lib"))
-::ENV["TOYS_BIN_PATH"] = ::File.absolute_path(__FILE__)
-load ::File.join(__dir__, "toys", "bin", "toys")
+dir=$(cd `dirname $0` && pwd)
+export TOYS_DEV=true
+export TOYS_CORE_LIB_PATH="$dir/toys-core/lib"
+export TOYS_BIN_PATH="$dir/toys-dev"
+exec ruby --disable=gems "$dir/toys/bin/toys" "$@"

--- a/toys/builtins/system.rb
+++ b/toys/builtins/system.rb
@@ -44,6 +44,7 @@ tool "update" do
   include :terminal
 
   def run
+    require "rubygems"
     configure_exec(exit_on_nonzero_status: true)
     version_info = spinner(leading_text: "Checking rubygems for the latest release... ",
                            final_text: "Done.\n") do

--- a/toys/lib/toys.rb
+++ b/toys/lib/toys.rb
@@ -28,8 +28,14 @@ require "toys/version"
 # We prepend to $LOAD_PATH directly rather than calling Kernel.gem, so that we
 # don't get clobbered in case someone sets up bundler later.
 ::ENV["TOYS_CORE_LIB_PATH"] ||= begin
-  dep = Gem::Dependency.new("toys-core", "= #{::Toys::VERSION}")
-  dep.to_spec.full_require_paths.first
+  path = ::File.expand_path("../../toys-core-#{::Toys::VERSION}/lib", __dir__)
+  unless path && ::File.directory?(path)
+    require "rubygems"
+    dep = ::Gem::Dependency.new("toys-core", "= #{::Toys::VERSION}")
+    path = dep.to_spec.full_require_paths.first
+  end
+  abort "Unable to find toys-core gem!" unless path && ::File.directory?(path)
+  path
 end
 $LOAD_PATH.unshift(::ENV["TOYS_CORE_LIB_PATH"])
 

--- a/toys/lib/toys/standard_cli.rb
+++ b/toys/lib/toys/standard_cli.rb
@@ -21,8 +21,6 @@
 # IN THE SOFTWARE.
 ;
 
-require "logger"
-
 module Toys
   ##
   # Subclass of `Toys::CLI` configured for the behavior of the standard Toys

--- a/toys/lib/toys/templates/gem_build.rb
+++ b/toys/lib/toys/templates/gem_build.rb
@@ -221,6 +221,7 @@ module Toys
           include :terminal
 
           to_run do
+            require "rubygems"
             require "rubygems/package"
             ::Dir.chdir(context_directory || ::Dir.getwd) do
               gem_name = template.gem_name

--- a/toys/toys.gemspec
+++ b/toys/toys.gemspec
@@ -55,6 +55,7 @@ require "toys/version"
 
   spec.add_dependency "toys-core", "= #{::Toys::VERSION}"
 
+  spec.add_development_dependency "did_you_mean", "~> 1.0"
   spec.add_development_dependency "highline", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-focus", "~> 1.1"


### PR DESCRIPTION
Experimental: removes the requirement that Rubygems is loaded before Toys is first executed.