### PR TITLE
fix: Various bundler related fixes

### DIFF
--- a/toys-core/Gemfile
+++ b/toys-core/Gemfile
@@ -13,5 +13,3 @@ gem "rdoc", "~> 6.1.2"
 gem "redcarpet", "~> 3.5" unless ::RUBY_PLATFORM == "java"
 gem "rubocop", "~> 0.81.0"
 gem "yard", "~> 0.9.25"
-
-@__toys_dev_gemspec = true

--- a/toys-core/lib/toys/compat.rb
+++ b/toys-core/lib/toys/compat.rb
@@ -33,7 +33,11 @@ module Toys
           require "did_you_mean"
         rescue ::LoadError
           require "rubygems"
-          require "did_you_mean" rescue nil # rubocop:disable Style/RescueModifier
+          begin
+            require "did_you_mean"
+          rescue ::LoadError
+            # Oh well, it's not available
+          end
         end
         @supports_suggestions = defined?(::DidYouMean::SpellChecker)
       end

--- a/toys-core/lib/toys/utils/gems/gemfile.rb
+++ b/toys-core/lib/toys/utils/gems/gemfile.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-unless defined?(@__toys_dev_gemspec)
-  gem("toys-core", ::Toys::Core::VERSION)
-  gem("toys", ::Toys::VERSION) if ::Toys.const_defined?(:VERSION)
-end

--- a/toys-core/test/gems-cases/activate-highline/run_test.rb
+++ b/toys-core/test/gems-cases/activate-highline/run_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "toys-core"
+require "toys/utils/gems"
+
+# Activate a gem
+Toys::Utils::Gems.new.activate("highline", "= 2.0.1")
+
+# Make sure it is accessible.
+require "highline"

--- a/toys-core/test/gems-cases/bundle-using-gemspec/Gemfile
+++ b/toys-core/test/gems-cases/bundle-using-gemspec/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/toys-core/test/gems-cases/bundle-using-gemspec/foobar.gemspec
+++ b/toys-core/test/gems-cases/bundle-using-gemspec/foobar.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ::Gem::Specification.new do |spec|
   spec.name = "foobar"
   spec.version = "0.0.1"

--- a/toys-core/test/gems-cases/bundle-using-gemspec/foobar.gemspec
+++ b/toys-core/test/gems-cases/bundle-using-gemspec/foobar.gemspec
@@ -1,0 +1,11 @@
+::Gem::Specification.new do |spec|
+  spec.name = "foobar"
+  spec.version = "0.0.1"
+  spec.summary = "Hello"
+  spec.authors = ["Me"]
+
+  spec.files = ::Dir.glob("lib/**/*.rb")
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "highline", "2.0.1"
+end

--- a/toys-core/test/gems-cases/bundle-using-gemspec/lib/foobar.rb
+++ b/toys-core/test/gems-cases/bundle-using-gemspec/lib/foobar.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Foobar
+end

--- a/toys-core/test/gems-cases/bundle-using-gemspec/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-using-gemspec/run_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "toys-core"
+require "toys/utils/gems"
+
+# Load the local bundle
+Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
+
+# Highline is in the local bundle. Make sure it is accessible.
+require "highline"
+
+# Make sure toys-core is still accessible.
+require "toys/utils/help_text"

--- a/toys-core/test/gems-cases/bundle-with-compatible-toys/Gemfile
+++ b/toys-core/test/gems-cases/bundle-with-compatible-toys/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "highline", "~> 2.0"
+gem "toys", ">= 0.10.0"

--- a/toys-core/test/gems-cases/bundle-with-compatible-toys/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-with-compatible-toys/run_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "toys-core"
+require "toys/utils/gems"
+
+# Load the local bundle
+Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
+
+# Highline is in the local bundle. Make sure it is accessible.
+require "highline"
+
+# Make sure toys-core is still accessible.
+require "toys/utils/help_text"

--- a/toys-core/test/gems-cases/bundle-with-incompatible-toys/Gemfile
+++ b/toys-core/test/gems-cases/bundle-with-incompatible-toys/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "highline", "~> 2.0"
+gem "toys", "= 0.10.0"

--- a/toys-core/test/gems-cases/bundle-with-incompatible-toys/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-with-incompatible-toys/run_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "toys-core"
+require "toys/utils/gems"
+
+# Load the local bundle
+Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
+
+# Shouldn't get here
+puts "should-not-get-here"

--- a/toys-core/test/gems-cases/bundle-without-toys/Gemfile
+++ b/toys-core/test/gems-cases/bundle-without-toys/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "highline", "2.0.2"

--- a/toys-core/test/gems-cases/bundle-without-toys/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-without-toys/run_test.rb
@@ -11,3 +11,6 @@ require "highline"
 
 # Make sure toys-core is still accessible.
 require "toys/utils/help_text"
+
+# Make sure supports_suggestions doesn't crash
+Toys::Compat.supports_suggestions?

--- a/toys-core/test/gems-cases/bundle-without-toys/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-without-toys/run_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "toys-core"
+require "toys/utils/gems"
+
+# Load the local bundle
+Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
+
+# Highline is in the local bundle. Make sure it is accessible.
+require "highline"
+
+# Make sure toys-core is still accessible.
+require "toys/utils/help_text"

--- a/toys-core/test/utils/test_exec.rb
+++ b/toys-core/test/utils/test_exec.rb
@@ -526,14 +526,14 @@ describe Toys::Utils::Exec do
     it "determines whether processes are executing" do
       ::Timeout.timeout(3) do
         controller1 = exec.exec("sleep 0.8", background: true)
-        controller2 = exec.exec("sleep 0.4", background: true)
-        sleep(0.3)
+        controller2 = exec.exec("sleep 0.3", background: true)
+        sleep(0.1)
         assert_equal(true, controller1.executing?)
         assert_equal(true, controller2.executing?)
-        sleep(0.4)
+        sleep(0.5)
         assert_equal(true, controller1.executing?)
         assert_equal(false, controller2.executing?)
-        sleep(0.4)
+        sleep(0.5)
         assert_equal(false, controller1.executing?)
         assert_equal(false, controller2.executing?)
       end

--- a/toys-core/test/utils/test_exec.rb
+++ b/toys-core/test/utils/test_exec.rb
@@ -525,15 +525,15 @@ describe Toys::Utils::Exec do
   describe "backgrounding" do
     it "determines whether processes are executing" do
       ::Timeout.timeout(3) do
-        controller1 = exec.exec("sleep 0.8", background: true)
+        controller1 = exec.exec("sleep 1", background: true)
         controller2 = exec.exec("sleep 0.3", background: true)
         sleep(0.1)
         assert_equal(true, controller1.executing?)
         assert_equal(true, controller2.executing?)
-        sleep(0.5)
+        sleep(0.7)
         assert_equal(true, controller1.executing?)
         assert_equal(false, controller2.executing?)
-        sleep(0.5)
+        sleep(0.7)
         assert_equal(false, controller1.executing?)
         assert_equal(false, controller2.executing?)
       end

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "helper"
+require "fileutils"
+require "timeout"
+
+describe Toys::Utils::Gems do
+  let(:gems_cases_dir) { File.join(File.dirname(__dir__), "gems-cases") }
+  describe "#bundle" do
+    let(:exec_service) { Toys::Utils::Exec.new }
+
+    def setup_case(name)
+      ::Bundler.with_unbundled_env do
+        Dir.chdir(File.join(gems_cases_dir, name)) do
+          ::Timeout.timeout(20) do
+            yield
+          end
+        end
+      end
+    end
+
+    def run_script(name = "run_test.rb", *args)
+      exec_service.exec_ruby(["-I#{Toys::CORE_LIB_PATH}", name, *args],
+                             out: :capture, err: :capture, in: :null)
+    end
+
+    it "sets up a bundle without toys" do
+      setup_case("bundle-without-toys") do
+        FileUtils.rm_f("Gemfile.lock")
+        result = run_script
+        assert(result.success?)
+        result = run_script
+        assert(result.success?)
+      end
+    end
+
+    it "sets up a bundle with compatible toys-core" do
+      setup_case("bundle-with-compatible-toys") do
+        FileUtils.rm_f("Gemfile.lock")
+        result = run_script
+        assert(result.success?)
+        result = run_script
+        assert(result.success?)
+      end
+    end
+
+    it "fails to set up a bundle with incompatible toys-core" do
+      setup_case("bundle-with-incompatible-toys") do
+        FileUtils.rm_f("Gemfile.lock")
+        result = run_script
+        refute(result.success?)
+        assert_match(/Toys::Utils::Gems::IncompatibleToysError/, result.captured_err)
+        refute_match(/should-not-get-here/, result.captured_out)
+      end
+    end
+
+    it "sets up a bundle requiring installation of a direct dependency" do
+      setup_case("bundle-without-toys") do
+        FileUtils.rm_f("Gemfile.lock")
+        exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.2"], out: :null)
+        result = run_script
+        assert(result.success?)
+        exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.2"], out: :null)
+        result = run_script
+        assert(result.success?)
+      end
+    end
+
+    it "sets up a bundle requiring installation of a transitive dependency via a gemspec" do
+      setup_case("bundle-using-gemspec") do
+        FileUtils.rm_f("Gemfile.lock")
+        exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.1"], out: :null)
+        result = run_script
+        assert(result.success?)
+        exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.1"], out: :null)
+        result = run_script
+        assert(result.success?)
+      end
+    end
+  end
+end

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -56,6 +56,7 @@ describe Toys::Utils::Gems do
     end
 
     it "sets up a bundle requiring installation of a direct dependency" do
+      skip if Toys::Compat.jruby?
       setup_case("bundle-without-toys") do
         FileUtils.rm_f("Gemfile.lock")
         exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.2"], out: :null)
@@ -68,6 +69,7 @@ describe Toys::Utils::Gems do
     end
 
     it "sets up a bundle requiring installation of a transitive dependency via a gemspec" do
+      skip if Toys::Compat.jruby?
       setup_case("bundle-using-gemspec") do
         FileUtils.rm_f("Gemfile.lock")
         exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.1"], out: :null)

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -3,6 +3,7 @@
 require "helper"
 require "fileutils"
 require "timeout"
+require "toys/utils/gems"
 
 describe Toys::Utils::Gems do
   let(:gems_cases_dir) { File.join(File.dirname(__dir__), "gems-cases") }

--- a/toys/Gemfile
+++ b/toys/Gemfile
@@ -16,5 +16,3 @@ gem "redcarpet", "~> 3.5" unless ::RUBY_PLATFORM == "java"
 gem "rspec", "~> 3.9"
 gem "rubocop", "~> 0.81.0"
 gem "yard", "~> 0.9.25"
-
-@__toys_dev_gemspec = true


### PR DESCRIPTION
* Silence bundler output (usually `Resolving dependencies...`) during bundle setup.
* Properly detect transitive dependencies that require installation.
* Allow `toys` or `toys-core` to be in the Gemfile. Check their version requirements against the running Toys version, and either pass it or raise the new `IncompatibleToysError`.
* Fix a crash when computing `did_you_mean` suggestions, when running with a bundle on Ruby 2.6 or earlier.
* Add tests for basic bundler integration cases.