### PR TITLE
fix: Don't modify bundler lockfiles when adding Toys to a bundle

### DIFF
--- a/toys-core/test/gems-cases/bundle-without-toys/Gemfile.lock.orig
+++ b/toys-core/test/gems-cases/bundle-without-toys/Gemfile.lock.orig
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    highline (2.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  highline (= 2.0.2)
+
+BUNDLED WITH
+   2.1.4

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -59,6 +59,17 @@ describe Toys::Utils::Gems do
       end
     end
 
+    it "restores the original Gemfile.lock" do
+      setup_case("bundle-without-toys") do
+        FileUtils.cp("Gemfile.lock.orig", "Gemfile.lock")
+        result = run_script
+        assert(result.success?)
+        cur_lockfile = File.read("Gemfile.lock")
+        orig_lockfile = File.read("Gemfile.lock.orig")
+        assert_equal(orig_lockfile, cur_lockfile)
+      end
+    end
+
     def clean_files_for_multi_tests
       files = ["Gemfile", "gems.rb", ".gems.rb", "Gemfile.lock", "gems.locked", ".gems.rb.lock"]
       files.each { |file| FileUtils.rm_f(file) }


### PR DESCRIPTION
Fixes #97 