### PR TITLE
fix!: Decouple tool definition from the tool DSL

### DIFF
--- a/toys-core/lib/toys/input_file.rb
+++ b/toys-core/lib/toys/input_file.rb
@@ -11,7 +11,7 @@ module Toys::InputFile # rubocop:disable Style/ClassAndModuleChildren
   end
 
   ## @private
-  def self.evaluate(tool_class, remaining_words, source)
+  def self.evaluate(tool_class, words, priority, remaining_words, source, loader)
     namespace = ::Module.new
     namespace.module_eval do
       include ::Toys::Context::Key
@@ -23,7 +23,7 @@ module Toys::InputFile # rubocop:disable Style/ClassAndModuleChildren
     str = build_eval_string(name, ::IO.read(path))
     if str
       const_set(name, namespace)
-      ::Toys::DSL::Tool.prepare(tool_class, remaining_words, source) do
+      ::Toys::DSL::Tool.prepare(tool_class, words, priority, remaining_words, source, loader) do
         ::Toys::ContextualError.capture_path("Error while loading Toys config!", path) do
           # rubocop:disable Security/Eval
           eval(str, __binding, path, -2)

--- a/toys-core/lib/toys/loader.rb
+++ b/toys-core/lib/toys/loader.rb
@@ -270,7 +270,7 @@ module Toys
     def build_tool(words, priority)
       parent = words.empty? ? nil : get_tool(words.slice(0..-2), priority)
       middleware_stack = parent ? parent.subtool_middleware_stack : @middleware_stack
-      Tool.new(self, parent, words, priority, middleware_stack, @middleware_lookup)
+      Tool.new(parent, words, priority, middleware_stack, @middleware_lookup)
     end
 
     ##
@@ -403,7 +403,7 @@ module Toys
       if remaining_words
         update_min_loaded_priority(priority)
         tool_class = get_tool(words, priority).tool_class
-        DSL::Tool.prepare(tool_class, remaining_words, source) do
+        DSL::Tool.prepare(tool_class, words, priority, remaining_words, source, self) do
           ContextualError.capture("Error while loading Toys config!") do
             tool_class.class_eval(&source.source_proc)
           end
@@ -425,7 +425,7 @@ module Toys
       if source.source_type == :file
         update_min_loaded_priority(priority)
         tool_class = get_tool(words, priority).tool_class
-        InputFile.evaluate(tool_class, remaining_words, source)
+        InputFile.evaluate(tool_class, words, priority, remaining_words, source, self)
       else
         do_preload(source.source_path)
         load_index_in(source, words, remaining_words, priority)

--- a/toys-core/lib/toys/standard_middleware/apply_config.rb
+++ b/toys-core/lib/toys/standard_middleware/apply_config.rb
@@ -30,9 +30,9 @@ module Toys
       # Appends the configuration block.
       # @private
       #
-      def config(tool, _loader)
+      def config(tool, loader)
         tool_class = tool.tool_class
-        DSL::Tool.prepare(tool_class, nil, @source_info) do
+        DSL::Tool.prepare(tool_class, tool.full_name, tool.priority, nil, @source_info, loader) do
           tool_class.class_eval(&@block)
         end
         yield

--- a/toys-core/test/test_tool.rb
+++ b/toys-core/test/test_tool.rb
@@ -763,7 +763,7 @@ describe Toys::Tool do
   describe "mixin module" do
     it "can be looked up from standard mixins" do
       test = self
-      tool.include_mixin(:fileutils)
+      tool.include_mixin(loader.resolve_standard_mixin("fileutils"))
       tool.run_handler = proc do
         test.assert_equal(true, private_methods.include?(:rm_rf))
       end
@@ -787,7 +787,7 @@ describe Toys::Tool do
     it "mixes into the executable tool" do
       test = self
       tool.add_mixin("mymixin", MyMixin)
-      tool.include_mixin("mymixin")
+      tool.include_mixin(tool.lookup_mixin("mymixin"))
       tool.run_handler = proc do
         test.assert_equal(:mixin1, mixin1)
       end
@@ -801,7 +801,7 @@ describe Toys::Tool do
           :bar
         end
       end
-      tool.include_mixin("mymixin")
+      tool.include_mixin(tool.lookup_mixin("mymixin"))
       tool.run_handler = proc do
         test.assert_equal(:bar, foo)
       end


### PR DESCRIPTION
This eliminates an awkward coupling where Toys::Tool depends on Toys::DSL::Tool and Toys::Loader. It is now possible to define a tool without the DSL and loader present.