### PR TITLE
chore: More fixes to class-based tool definition and tool inheritance

### DIFF
--- a/toys-core/lib/toys/dsl/tool.rb
+++ b/toys-core/lib/toys/dsl/tool.rb
@@ -329,7 +329,6 @@ module Toys
         end
         self
       end
-      alias name tool
 
       ##
       # Create an alias, representing an "alternate name" for a tool.

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -1327,17 +1327,17 @@ module Toys
     #
     # The following settings are supported:
     #
-    #  *  `inherit_parent_methods` (_Boolean_) - Whether subtools should
+    #  *  `propagate_helper_methods` (_Boolean_) - Whether subtools should
     #     inherit methods defined by parent tools. Defaults to `false`.
     #
     class Settings < ::Toys::Settings
-      settings_attr :inherit_parent_methods, default: false
+      settings_attr :propagate_helper_methods, default: false
     end
 
     private
 
     def create_class
-      ::Class.new(@parent&.settings&.inherit_parent_methods ? @parent.tool_class : ::Toys::Context)
+      ::Class.new(@parent&.settings&.propagate_helper_methods ? @parent.tool_class : ::Toys::Context)
     end
 
     def make_config_proc(middleware, loader, next_config)

--- a/toys-core/test/lookup-cases/tool-subclasses/.toys.rb
+++ b/toys-core/test/lookup-cases/tool-subclasses/.toys.rb
@@ -2,16 +2,68 @@
 
 class Foo < Toys::Tool
   desc "description of foo"
+
+  def foo
+    exit 9
+  end
+
+  def run
+    foo
+  end
 end
 
 class FooBar < Toys::Tool
   desc "description of foo-bar"
 
-  class Baz < Toys::Tool
+  class Baz < Toys.Tool()
     desc "description of foo-bar baz"
   end
 
   tool "qux" do
     desc "description of foo-bar qux"
+  end
+end
+
+class Quux < Toys.Tool("qu_ux")
+  desc "description of qu_ux"
+
+  def quux
+    exit 8
+  end
+
+  def run
+    quux
+  end
+end
+
+class FooChild1 < Foo
+  desc "description of foo-child1"
+
+  def run
+    foo
+  end
+end
+
+class FooChild2 < Toys.Tool(name: "foo_child2", base: Foo)
+  desc "description of foo_child2"
+
+  def run
+    foo
+  end
+end
+
+class QuuxChild1 < Quux
+  desc "description of quux-child1"
+
+  def run
+    quux
+  end
+end
+
+class QuuxChild2 < Toys.Tool("quux_child2", Quux)
+  desc "description of quux_child2"
+
+  def run
+    quux
   end
 end

--- a/toys-core/test/test_dsl.rb
+++ b/toys-core/test/test_dsl.rb
@@ -1606,18 +1606,18 @@ describe Toys::DSL::Tool do
     it "returns the settings" do
       test = self
       loader.add_block do
-        test.assert_equal(false, settings.inherit_parent_methods)
-        settings.inherit_parent_methods = true
-        test.assert_equal(true, settings.inherit_parent_methods)
+        test.assert_equal(false, settings.propagate_helper_methods)
+        settings.propagate_helper_methods = true
+        test.assert_equal(true, settings.propagate_helper_methods)
       end
     end
 
     it "inherits settings of parent tool" do
       test = self
       loader.add_block do
-        settings.inherit_parent_methods = true
+        settings.propagate_helper_methods = true
         tool "tool-1" do
-          test.assert_equal(true, settings.inherit_parent_methods)
+          test.assert_equal(true, settings.propagate_helper_methods)
         end
       end
     end
@@ -1668,6 +1668,40 @@ describe Toys::DSL::Tool do
       loader.add_path(File.join(cases_dir, "tool-subclasses"))
       tool, _remaining = loader.lookup(["foo-bar", "qux"])
       assert_equal("description of foo-bar qux", tool.desc.to_s)
+    end
+
+    it "creates a tool with a custom name" do
+      loader.add_path(File.join(cases_dir, "tool-subclasses"))
+      tool, _remaining = loader.lookup(["qu_ux"])
+      assert_equal("description of qu_ux", tool.desc.to_s)
+    end
+
+    it "creates a tool subclassing an existing tool" do
+      loader.add_path(File.join(cases_dir, "tool-subclasses"))
+      tool, _remaining = loader.lookup(["foo-child1"])
+      assert_equal("description of foo-child1", tool.desc.to_s)
+      assert_equal(9, cli.run(["foo-child1"]))
+    end
+
+    it "creates a custom-named tool subclassing an existing tool" do
+      loader.add_path(File.join(cases_dir, "tool-subclasses"))
+      tool, _remaining = loader.lookup(["foo_child2"])
+      assert_equal("description of foo_child2", tool.desc.to_s)
+      assert_equal(9, cli.run(["foo_child2"]))
+    end
+
+    it "creates a tool subclassing an existing custom-named tool" do
+      loader.add_path(File.join(cases_dir, "tool-subclasses"))
+      tool, _remaining = loader.lookup(["quux-child1"])
+      assert_equal("description of quux-child1", tool.desc.to_s)
+      assert_equal(8, cli.run(["quux-child1"]))
+    end
+
+    it "creates a custom-named tool subclassing an existing custom-named tool" do
+      loader.add_path(File.join(cases_dir, "tool-subclasses"))
+      tool, _remaining = loader.lookup(["quux_child2"])
+      assert_equal("description of quux_child2", tool.desc.to_s)
+      assert_equal(8, cli.run(["quux_child2"]))
     end
 
     it "is not allowed outside the DSL" do

--- a/toys-core/test/test_tool_definition.rb
+++ b/toys-core/test/test_tool_definition.rb
@@ -972,7 +972,7 @@ describe Toys::ToolDefinition do
   end
 
   describe "settings" do
-    it "honors inherit_parent_methods false" do
+    it "honors propagate_helper_methods false" do
       tool.tool_class.class_eval do
         def foo
           5
@@ -982,8 +982,8 @@ describe Toys::ToolDefinition do
       refute_includes(subtool.tool_class.public_instance_methods, :foo)
     end
 
-    it "honors inherit_parent_methods true" do
-      tool.settings.inherit_parent_methods = true
+    it "honors propagate_helper_methods true" do
+      tool.settings.propagate_helper_methods = true
       tool.tool_class.class_eval do
         def foo
           5


### PR DESCRIPTION
* Renamed the setting for tool helper method inheritance to `propagate_helper_methods`.
* Removed the `name` alias for the `tool` directive.
* Fixed a crash when subclassing an existing tool using class-based tool definition
* Toys.Tool supports setting both a superclass and a tool name