### PR TITLE
fix: Restrict certain characters from tool names

### DIFF
--- a/toys-core/lib/toys/errors.rb
+++ b/toys-core/lib/toys/errors.rb
@@ -54,6 +54,7 @@ module Toys
       @config_line = config_line
       @tool_name = tool_name
       @tool_args = tool_args
+      set_backtrace(cause.backtrace)
     end
 
     attr_reader :cause

--- a/toys/builtins/system/.test/test_main.rb
+++ b/toys/builtins/system/.test/test_main.rb
@@ -1,14 +1,22 @@
 describe "toys system" do
   include Toys::Testing
 
+  def universal_capture(cmd)
+    if Toys::Compat.allow_fork?
+      capture_tool(cmd)
+    else
+      capture_separate_tool(cmd)
+    end
+  end
+
   it "prints the description" do
-    output = capture_tool(["system"])
+    output = universal_capture(["system"])
     assert_includes(output, "A set of system commands for Toys")
   end
 
   describe "version" do
     it "prints the current version" do
-      output = capture_tool(["system", "version"])
+      output = universal_capture(["system", "version"])
       assert_includes(output, Toys::VERSION)
     end
   end

--- a/toys/builtins/system/test.rb
+++ b/toys/builtins/system/test.rb
@@ -15,8 +15,8 @@ flag :exclude, "-e", "--exclude PATTERN",
      desc: "Exclude /regexp/ or string from run."
 flag :recursive, "--[no-]recursive", default: true,
      desc: "Recursively test subtools (default is true)"
-
-remaining_args :tool_path
+flag :tool, "-t TOOL", "--tool TOOL", default: "",
+     desc: "Run tests only for tools under the given path"
 
 include :exec
 include :gems
@@ -56,13 +56,13 @@ def find_test_files
 end
 
 def tool_dir
-  words = tool_path.size == 1 ? cli.loader.split_path(tool_path.first) : tool_path
+  words = cli.loader.split_path(tool)
   dir = base_dir
   unless words.empty?
     dir = ::File.join(dir, *words)
     unless ::File.directory?(dir)
-      logger.error("No such directory: #{dir}")
-      exit(1)
+      logger.warn("No such directory: #{dir}")
+      exit
     end
   end
   dir

--- a/toys/test/test_builtins.rb
+++ b/toys/test/test_builtins.rb
@@ -133,6 +133,41 @@ describe "toys" do
         end
       end
     end
+
+    describe "test" do
+      let(:builtins_dir) { File.join(File.dirname(__dir__), "builtins") }
+
+      it "runs for the given tool path" do
+        output = Toys::TestHelper.capture_toys("system", "test",
+                                               "-d", builtins_dir,
+                                               "--no-recursive",
+                                               "-t", "system")
+        assert_match(/0 failures, 0 errors, 0 skips/, output)
+      end
+
+      it "runs recursively" do
+        output = Toys::TestHelper.capture_toys("system", "test",
+                                               "-d", builtins_dir)
+        assert_match(/0 failures, 0 errors, 0 skips/, output)
+      end
+
+      it "honors --no-recursive" do
+        output = Toys::TestHelper.capture_toys("system", "test",
+                                               "-d", builtins_dir,
+                                               "--no-recursive",
+                                               stream: :err)
+        assert_match(/No test files found/, output)
+      end
+
+      it "reports that the given tool has no tests" do
+        output = Toys::TestHelper.capture_toys("system", "test",
+                                               "-d", builtins_dir,
+                                               "--no-recursive",
+                                               "-t", "do",
+                                               stream: :err)
+        assert_match(/No such directory/, output)
+      end
+    end
   end
 
   describe "do" do


### PR DESCRIPTION
* Raises errors if attempting to define a tool whose name contains whitespace, control characters, or one of the following reserved characters: ```#"$&'()*;<>[\]^`{|}```
* Whitespace is now automatically a tool name delimiter.
* Fixes Toys::ContextualError so it reports the entire backtrace of the cause.
* Some memory cleanup during tool load/lookup.
