### PR TITLE
chore: Updates to build and tests

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -8,13 +8,17 @@ long_desc "The CI tool runs all CI checks for both gems, including unit" \
             " entrypoint for CI systems. Any failure will result in a" \
             " nonzero result code."
 
+flag :integration_tests, desc: "Enable integration tests"
+
 include :terminal
 include :exec
 
 def handle_gem(gem_name)
   puts("**** CHECKING #{gem_name.upcase} GEM...", :bold, :cyan)
   ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    result = exec_separate_tool("ci")
+    env = {}
+    env["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
+    result = exec_separate_tool("ci", env: env)
     if result.success?
       puts("**** #{gem_name.upcase} GEM OK.", :bold, :cyan)
     else

--- a/toys-core/.toys.rb
+++ b/toys-core/.toys.rb
@@ -37,6 +37,8 @@ tool "ci" do
               " the entrypoint for CI systems. Any failure will result in a" \
               " nonzero result code."
 
+  flag :integration_tests, desc: "Enable integration tests"
+
   include :exec, result_callback: :handle_result
   include :terminal
 
@@ -50,7 +52,9 @@ tool "ci" do
   end
 
   def run
-    exec_tool(["test"], name: "Tests")
+    env = {}
+    env["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
+    exec_tool(["test"], name: "Tests", env: env)
     exec_tool(["rubocop"], name: "Style checker")
     exec_tool(["yardoc-full"], name: "Docs generation")
     exec_tool(["build"], name: "Gem build")

--- a/toys-core/Gemfile
+++ b/toys-core/Gemfile
@@ -4,12 +4,15 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "did_you_mean", "~> 1.0"
+# The bundler in Ruby < 3.1 triggers a deprecation warning in did_you_mean 1.6
+# resulting in test failures due to the unexpected output.
+did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : ["~> 1.0"]
+gem "did_you_mean", *did_you_mean_versions
 gem "highline", "~> 2.0"
 gem "minitest", "~> 5.14"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
-gem "rdoc", "~> 6.2.1"
+gem "rdoc", "~> 6.3.3"
 gem "redcarpet", "~> 3.5" unless ::RUBY_PLATFORM == "java"
 gem "rubocop", "~> 1.12.1"
 gem "yard", "~> 0.9.25"

--- a/toys-core/test/gems-cases/bundle-update-required/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-update-required/run_test.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+puts "***"
 require "toys-core"
 require "toys/utils/gems"
+puts "*****"
 
 # Load the local bundle
 Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
+puts "**********"

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -170,11 +170,10 @@ describe Toys::Utils::Gems do
       setup_case("bundle-update-required") do
         FileUtils.rm_f("Gemfile.lock")
         FileUtils.cp("Gemfile.lock.orig", "Gemfile.lock")
+        exec_service.exec(["gem", "uninstall", "rubocop", "--version=0.81.0"], out: :null)
         result = run_script
         assert(result.success?)
         assert_match(/Your bundle requires additional gems\. Install\?/, result.captured_out)
-        assert_match(/Failed to install\. Trying update\.\.\./, result.captured_out)
-        assert_match(/Bundle updated!/, result.captured_out)
         result = run_script
         assert(result.success?)
         refute_match(/Your bundle requires additional gems\. Install\?/, result.captured_out)

--- a/toys/.toys.rb
+++ b/toys/.toys.rb
@@ -37,6 +37,8 @@ tool "ci" do
               " entrypoint for CI systems. Any failure will result in a" \
               " nonzero result code."
 
+  flag :integration_tests, desc: "Enable integration tests"
+
   include :exec, result_callback: :handle_result
   include :terminal
 
@@ -50,7 +52,9 @@ tool "ci" do
   end
 
   def run
-    exec_tool(["test"], name: "Tests")
+    env = {}
+    env["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
+    exec_tool(["test"], name: "Tests", env: env)
     exec_tool(["rubocop"], name: "Style checker")
     exec_tool(["yardoc-full"], name: "Docs generation")
     exec_tool(["build"], name: "Gem build")

--- a/toys/Gemfile
+++ b/toys/Gemfile
@@ -5,13 +5,16 @@ source "https://rubygems.org"
 gemspec
 gem "toys-core", path: "../toys-core"
 
-gem "did_you_mean", "~> 1.0"
+# The bundler in Ruby < 3.1 triggers a deprecation warning in did_you_mean 1.6
+# resulting in test failures due to the unexpected output.
+did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : ["~> 1.0"]
+gem "did_you_mean", *did_you_mean_versions
 gem "highline", "~> 2.0"
 gem "minitest", "~> 5.14"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
 gem "rake", "~> 13.0"
-gem "rdoc", "~> 6.2.1"
+gem "rdoc", "~> 6.3.3"
 gem "redcarpet", "~> 3.5" unless ::RUBY_PLATFORM == "java"
 gem "rspec", "~> 3.9"
 gem "rubocop", "~> 1.12.1"

--- a/toys/lib/toys.rb
+++ b/toys/lib/toys.rb
@@ -6,7 +6,7 @@ require "toys/version"
 # environment variable explicitly, but in production, we get it from rubygems.
 # We prepend to $LOAD_PATH directly rather than calling Kernel.gem, so that we
 # don't get clobbered in case someone sets up bundler later.
-::ENV["TOYS_CORE_LIB_PATH"] ||= begin
+unless ::ENV.key?("TOYS_CORE_LIB_PATH")
   path = ::File.expand_path("../../toys-core-#{::Toys::VERSION}/lib", __dir__)
   unless path && ::File.directory?(path)
     require "rubygems"
@@ -14,7 +14,7 @@ require "toys/version"
     path = dep.to_spec.full_require_paths.first
   end
   abort "Unable to find toys-core gem!" unless path && ::File.directory?(path)
-  path
+  ::ENV.store("TOYS_CORE_LIB_PATH", path)
 end
 
 $LOAD_PATH.delete(::ENV["TOYS_CORE_LIB_PATH"])


### PR DESCRIPTION
Changes include:
* Added `--integration-tests` flag to the `toys ci` tools
* Updated rdoc test dependencies to handle security warning
* Pinned `did_you_mean` to 1.5 on Ruby < 3.1 to avoid a bundler deprecation warning
* Updated the bundle-update test to work around behavior changes in newer versions of bundler
* Workaround for a bug in yard 0.9.27 (https://github.com/lsegal/yard/issues/1420)

Ruby 3.1 is not yet added to CI because of an issue with bundler 2.3.