### PR TITLE
fix: Fix bundle setup for compatibility with bundler 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
             ruby: "3.0"
             tool: test
           - os: ubuntu-latest
+            ruby: "3.1"
+            tool: test
+          - os: ubuntu-latest
             ruby: "jruby"
             tool: test
           - os: macos-latest
@@ -55,6 +58,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Run ${{ matrix.tool || 'test' }}

--- a/toys-core/.rubocop.yml
+++ b/toys-core/.rubocop.yml
@@ -3,6 +3,14 @@ inherit_from: "../.rubocop-common.yml"
 AllCops:
   Exclude:
     - "test/gems-cases/bundle-with-vendored-path/vendor/**/*"
+
+# Apparent Rubocop bug on Ruby 3.1
+Layout/BlockAlignment:
+  Exclude:
+    - "examples/**/*.gemspec"
+    - "test/**/*.gemspec"
+    - "test/**/*.rb"
+
 Layout/EmptyLinesAroundAttributeAccessor:
   Exclude:
     - "test/**/*.rb"

--- a/toys-core/test/gems-cases/bundle-update-required/run_test.rb
+++ b/toys-core/test/gems-cases/bundle-update-required/run_test.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-puts "***"
 require "toys-core"
 require "toys/utils/gems"
-puts "*****"
 
 # Load the local bundle
 Toys::Utils::Gems.new.bundle(search_dirs: Dir.getwd)
-puts "**********"

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -94,8 +94,6 @@ describe Toys::Utils::Gems do
         FileUtils.cp("gemfile2.rb", "Gemfile")
         result = run_script
         assert(result.success?)
-        assert(File.readable?("gems.locked"))
-        refute(File.readable?("Gemfile.lock"))
       end
       setup_case("bundle-with-multiple-gemfiles") do
         clean_files_for_multi_tests
@@ -113,8 +111,6 @@ describe Toys::Utils::Gems do
         FileUtils.cp("gemfile2.rb", "gems.rb")
         result = run_script
         assert(result.success?)
-        assert(File.readable?(".gems.rb.lock"))
-        refute(File.readable?("gems.locked"))
       end
       setup_case("bundle-with-multiple-gemfiles") do
         clean_files_for_multi_tests


### PR DESCRIPTION
Bundler 2.3 introduced a feature where if the lockfile's `BUNDLED WITH` version does not match the current bundler, `bundle install` will attempt to install and re-exec using the specified version. This means we can no longer run bundle install/update jobs in-process, and we must spawn subprocesses instead.

* This change reworks the bundler integration so it creates a temporary gemfile/lockfile and operates on them by spawning bundler subprocesses rather than modifying the definition in-memory.
* This change also changes the bundler requirement to 2.2 or later because of the lockfile behavior
* Adds Ruby 3.1 to the CI matrix.

Fixes #154