### PR TITLE
fix: Support for Truffleruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           - os: ubuntu-latest
             ruby: "jruby"
             tool: test
+          - os: ubuntu-latest
+            ruby: "truffleruby"
+            tool: test
           - os: macos-latest
             ruby: "2.4"
             tool: test

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Toys requires Ruby 2.4 or later.
 Most parts of Toys work on JRuby. However, JRuby is not recommended because of
 JVM boot latency, lack of support for Kernel#fork, and other issues.
 
+Most parts of Toys work on TruffleRuby. However, TruffleRuby is not recommended
+because it has a few known bugs that affect Toys.
+
 ### Write your first tool
 
 You can define tools by creating a *Toys file*. Go into any directory, and,

--- a/toys-core/README.md
+++ b/toys-core/README.md
@@ -39,6 +39,9 @@ Toys-Core requires Ruby 2.4 or later.
 Most parts of Toys-Core work on JRuby. However, JRuby is not recommended
 because of JVM boot latency, lack of support for Kernel#fork, and other issues.
 
+Most parts of Toys-Core work on TruffleRuby. However, TruffleRuby is not
+recommended because it has a few known bugs that affect Toys.
+
 ### Create a new executable
 
 We'll start by creating an executable Ruby script. Using your favorite text

--- a/toys-core/lib/toys/compat.rb
+++ b/toys-core/lib/toys/compat.rb
@@ -13,7 +13,12 @@ module Toys
 
     # @private
     def self.jruby?
-      ::RUBY_PLATFORM == "java"
+      ::RUBY_ENGINE == "jruby"
+    end
+
+    # @private
+    def self.truffleruby?
+      ::RUBY_ENGINE == "truffleruby"
     end
 
     # @private
@@ -23,7 +28,7 @@ module Toys
 
     # @private
     def self.allow_fork?
-      !jruby? && !windows?
+      !jruby? && !truffleruby? && !windows?
     end
 
     # @private
@@ -68,7 +73,9 @@ module Toys
 
     # Due to a bug in Ruby < 2.7, passing an empty **kwargs splat to
     # initialize will fail if there are no formal keyword args.
-    if ruby_version >= 20700
+    # This also hits TruffleRuby
+    # (see https://github.com/oracle/truffleruby/issues/2567)
+    if ruby_version >= 20700 && !truffleruby?
       # @private
       def self.instantiate(klass, args, kwargs, block)
         klass.new(*args, **kwargs, &block)

--- a/toys-core/test/mixins/test_exec.rb
+++ b/toys-core/test/mixins/test_exec.rb
@@ -318,12 +318,12 @@ describe Toys::StandardMixins::Exec do
         tool "foo" do
           include :exec, exit_on_nonzero_status: true
           to_run do
-            exec("exit 3")
+            exec(["false"])
             completed = true
           end
         end
       end
-      assert_equal(3, cli.run("foo"))
+      refute_equal(0, cli.run("foo"))
       refute(completed)
     end
 

--- a/toys-core/test/test_acceptor.rb
+++ b/toys-core/test/test_acceptor.rb
@@ -534,10 +534,12 @@ describe Toys::Acceptor do
       end
 
       it "does not accept empty string" do
+        skip("https://github.com/oracle/truffleruby/issues/2566") if Toys::Compat.truffleruby?
         refute_accept(acceptor, "")
       end
 
       it "does not accept nonnumeric string" do
+        skip("https://github.com/oracle/truffleruby/issues/2566") if Toys::Compat.truffleruby?
         refute_accept(acceptor, "hi")
       end
 

--- a/toys-core/test/test_wrappable_string.rb
+++ b/toys-core/test/test_wrappable_string.rb
@@ -16,6 +16,7 @@ describe Toys::WrappableString do
     end
 
     it "handles whitespace string" do
+      skip("https://github.com/oracle/truffleruby/issues/2565") if Toys::Compat.truffleruby?
       result = Toys::WrappableString.new(" \n ").wrap(10)
       assert_equal([], result)
     end

--- a/toys-core/test/utils/test_gems.rb
+++ b/toys-core/test/utils/test_gems.rb
@@ -122,7 +122,7 @@ describe Toys::Utils::Gems do
     end
 
     it "sets up a bundle requiring installation of a direct dependency" do
-      skip if Toys::Compat.jruby?
+      skip if Toys::Compat.jruby? || Toys::Compat.truffleruby?
       setup_case("bundle-without-toys") do
         FileUtils.rm_f("Gemfile.lock")
         exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.2"], out: :null)
@@ -142,7 +142,7 @@ describe Toys::Utils::Gems do
     end
 
     it "sets up a bundle requiring installation of a transitive dependency via a gemspec" do
-      skip if Toys::Compat.jruby?
+      skip if Toys::Compat.jruby? || Toys::Compat.truffleruby?
       setup_case("bundle-using-gemspec") do
         FileUtils.rm_f("Gemfile.lock")
         exec_service.exec(["gem", "uninstall", "highline", "--version=2.0.1"], out: :null)
@@ -162,7 +162,7 @@ describe Toys::Utils::Gems do
     end
 
     it "updates the bundle if install fails due to conflicts" do
-      skip if Toys::Compat.jruby?
+      skip if Toys::Compat.jruby? || Toys::Compat.truffleruby?
       setup_case("bundle-update-required") do
         FileUtils.rm_f("Gemfile.lock")
         FileUtils.cp("Gemfile.lock.orig", "Gemfile.lock")

--- a/toys/README.md
+++ b/toys/README.md
@@ -55,6 +55,9 @@ Toys requires Ruby 2.4 or later.
 Most parts of Toys work on JRuby. However, JRuby is not recommended because of
 JVM boot latency, lack of support for Kernel#fork, and other issues.
 
+Most parts of Toys work on TruffleRuby. However, TruffleRuby is not recommended
+because it has a few known bugs that affect Toys.
+
 ### Write your first tool
 
 You can define tools by creating a *Toys file*. Go into any directory, and,


### PR DESCRIPTION
Adds TruffleRuby to the CI matrix, and provides a few workarounds (and skips a few tests) to address known bugs. TruffleRuby bugs that impact Toys include:

* https://github.com/oracle/truffleruby/issues/2565
* https://github.com/oracle/truffleruby/issues/2566
* https://github.com/oracle/truffleruby/issues/2567
* https://github.com/oracle/truffleruby/issues/2568