### PR TITLE
feat: Implement system tools show and system tools list builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,16 @@ jobs:
             ruby: "2.4"
             tool: test
           - os: macos-latest
-            ruby: "3.0"
+            ruby: "3.1"
             tool: test
           - os: windows-latest
             ruby: "2.4"
             tool: test
           - os: windows-latest
-            ruby: "3.0"
+            ruby: "3.1"
             tool: test
           - os: ubuntu-latest
-            ruby: "3.0"
+            ruby: "3.1"
             tool: "rubocop , yardoc , build"
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.toys/build.rb
+++ b/.toys/build.rb
@@ -5,14 +5,12 @@ desc "Checks build for both gems"
 include :terminal
 include :exec, exit_on_nonzero_status: true
 
-def handle_gem(gem_name)
-  puts("**** Building #{gem_name}...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    exec_separate_tool("build")
-  end
-end
-
 def run
-  handle_gem("toys-core")
-  handle_gem("toys")
+  ::Dir.chdir(context_directory)
+
+  puts("**** Building toys-core...", :bold, :cyan)
+  exec_separate_tool(["build"], chdir: "toys-core")
+
+  puts("**** Building toys...", :bold, :cyan)
+  exec_separate_tool(["build"], chdir: "toys")
 end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -15,16 +15,14 @@ include :exec
 
 def handle_gem(gem_name)
   puts("**** CHECKING #{gem_name.upcase} GEM...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    env = {}
-    env["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
-    result = exec_separate_tool("ci", env: env)
-    if result.success?
-      puts("**** #{gem_name.upcase} GEM OK.", :bold, :cyan)
-    else
-      puts("**** #{gem_name.upcase} GEM FAILED!", :red, :bold)
-      exit(result.exit_code)
-    end
+  env = {}
+  env["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
+  result = exec_separate_tool("ci", env: env, chdir: gem_name)
+  if result.success?
+    puts("**** #{gem_name.upcase} GEM OK.", :bold, :cyan)
+  else
+    puts("**** #{gem_name.upcase} GEM FAILED!", :red, :bold)
+    exit(result.exit_code)
   end
 end
 

--- a/.toys/install.rb
+++ b/.toys/install.rb
@@ -5,14 +5,12 @@ desc "Build and install the current gems"
 include :terminal
 include :exec, exit_on_nonzero_status: true
 
-def handle_gem(gem_name)
-  puts("**** Installing #{gem_name} from local build...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    exec_separate_tool(["install", "-y"])
-  end
-end
-
 def run
-  handle_gem("toys-core")
-  handle_gem("toys")
+  ::Dir.chdir(context_directory)
+
+  puts("**** Installing toys-core from local build...", :bold, :cyan)
+  exec_separate_tool(["install", "-y"], chdir: "toys-core")
+
+  puts("**** Installing toys from local build...", :bold, :cyan)
+  exec_separate_tool(["install", "-y"], chdir: "toys")
 end

--- a/.toys/rubocop.rb
+++ b/.toys/rubocop.rb
@@ -5,19 +5,17 @@ desc "Runs rubocop in both gems"
 include :terminal
 include :exec, exit_on_nonzero_status: true
 
-def handle_gem(gem_name)
-  puts("**** Running rubocop on #{gem_name}...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    exec_separate_tool("rubocop")
-  end
-end
-
 def run
   ::Dir.chdir(context_directory)
+
   puts("**** Running rubocop on repo root...", :bold, :cyan)
   exec_separate_tool(["rubocop", "_root"])
-  handle_gem("toys-core")
-  handle_gem("toys")
+
+  puts("**** Running rubocop on toys-core...", :bold, :cyan)
+  exec_separate_tool(["rubocop"], chdir: "toys-core")
+
+  puts("**** Running rubocop on toys...", :bold, :cyan)
+  exec_separate_tool(["rubocop"], chdir: "toys")
 end
 
 expand :rubocop do |t|

--- a/.toys/test.rb
+++ b/.toys/test.rb
@@ -7,15 +7,16 @@ flag :integration_tests, "--integration-tests", "--integration", desc: "Enable i
 include :terminal
 include :exec, exit_on_nonzero_status: true
 
-def handle_gem(gem_name)
-  puts("**** Testing #{gem_name}...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    exec_separate_tool("test")
-  end
-end
-
 def run
   ::ENV["TOYS_TEST_INTEGRATION"] = "true" if integration_tests
-  handle_gem("toys-core")
-  handle_gem("toys")
+  ::Dir.chdir(context_directory)
+
+  puts("**** Testing toys-core...", :bold, :cyan)
+  exec_separate_tool(["test"], chdir: "toys-core")
+
+  puts("**** Testing toys...", :bold, :cyan)
+  exec_separate_tool(["test"], chdir: "toys")
+
+  puts("**** Testing builtins...", :bold, :cyan)
+  exec_separate_tool(["test-builtins"], chdir: "toys")
 end

--- a/.toys/update-bundles.rb
+++ b/.toys/update-bundles.rb
@@ -11,10 +11,9 @@ def run
   puts("**** Updating root bundle...", :bold, :cyan)
   exec(["bundle", "update"])
 
-  ["toys-core", "toys"].each do |gem_name|
-    puts("**** Updating #{gem_name} bundle...", :bold, :cyan)
-    ::Dir.chdir(gem_name) do
-      exec(["bundle", "update"])
-    end
-  end
+  puts("**** Updating toys-core bundle...", :bold, :cyan)
+  exec(["bundle", "update"], chdir: "toys-core")
+
+  puts("**** Updating toys bundle...", :bold, :cyan)
+  exec(["bundle", "update"], chdir: "toys")
 end

--- a/.toys/yardoc.rb
+++ b/.toys/yardoc.rb
@@ -7,14 +7,13 @@ flag :test
 include :terminal
 include :exec, exit_on_nonzero_status: true
 
-def handle_gem(gem_name)
-  puts("**** Generating Yardoc for #{gem_name}...", :bold, :cyan)
-  ::Dir.chdir(::File.join(context_directory, gem_name)) do
-    exec_separate_tool(test ? "yardoc-test" : "yardoc")
-  end
-end
-
 def run
-  handle_gem("toys-core")
-  handle_gem("toys")
+  ::Dir.chdir(context_directory)
+  tool = [test ? "yardoc-test" : "yardoc"]
+
+  puts("**** Generating Yardoc for toys-core...", :bold, :cyan)
+  exec_separate_tool(tool, chdir: "toys-core")
+
+  puts("**** Generating Yardoc for toys...", :bold, :cyan)
+  exec_separate_tool(tool, chdir: "toys")
 end

--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -226,9 +226,9 @@ module Toys
     end
 
     ##
-    # Make a clone with the same settings but no no config blocks and no paths
-    # in the loader. This is sometimes useful for calling another tool that has
-    # to be loaded from a different configuration.
+    # Make a clone with the same settings but no config blocks and no paths in
+    # the loader. This is sometimes useful for calling another tool that has to
+    # be loaded from a different configuration.
     #
     # @param opts [keywords] Any configuration arguments that should be
     #     modified from the original. See {#initialize} for a list of

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -136,7 +136,9 @@ module Toys
         tool_name, prefix, fragment = analyze_subtool_fragment(context)
         return unless tool_name
         subtools = context.cli.loader.list_subtools(tool_name,
-                                                    include_hidden: @include_hidden_subtools)
+                                                    include_namespaces: true,
+                                                    include_hidden: @include_hidden_subtools,
+                                                    include_non_runnable: @include_hidden_subtools)
         return if subtools.empty?
         candidates = []
         subtools.each do |subtool|

--- a/toys-core/lib/toys/utils/help_text.rb
+++ b/toys-core/lib/toys/utils/help_text.rb
@@ -171,7 +171,10 @@ module Toys
         ([@tool] + @delegates).each do |tool|
           name_len = tool.full_name.length
           subtools = @loader.list_subtools(tool.full_name,
-                                           recursive: recursive, include_hidden: include_hidden)
+                                           recursive: recursive,
+                                           include_hidden: include_hidden,
+                                           include_namespaces: include_hidden,
+                                           include_non_runnable: include_hidden)
           subtools.each do |subtool|
             local_name = subtool.full_name.slice(name_len..-1).join(" ")
             subtools_by_name[local_name] = subtool

--- a/toys-core/test/middleware/test_show_help.rb
+++ b/toys-core/test/middleware/test_show_help.rb
@@ -79,9 +79,11 @@ describe Toys::StandardMiddleware::ShowHelp do
     cli.add_config_block do
       tool "foo" do
         desc "beyond all recognition"
+        def run; end
       end
       tool "bar" do
         desc "was met"
+        def run; end
       end
     end
     cli.run("--search", "bar")
@@ -94,6 +96,7 @@ describe Toys::StandardMiddleware::ShowHelp do
     cli.add_config_block do
       tool "_bar" do
         desc "was met"
+        def run; end
       end
     end
     cli.run
@@ -105,6 +108,7 @@ describe Toys::StandardMiddleware::ShowHelp do
     cli.add_config_block do
       tool "_bar" do
         desc "was met"
+        def run; end
       end
     end
     cli.run("--all")
@@ -118,6 +122,7 @@ describe Toys::StandardMiddleware::ShowHelp do
         desc "beyond all recognition"
         tool "bar" do
           desc "was met"
+          def run; end
         end
       end
     end
@@ -132,6 +137,7 @@ describe Toys::StandardMiddleware::ShowHelp do
         desc "beyond all recognition"
         tool "bar" do
           desc "was met"
+          def run; end
         end
       end
     end
@@ -146,6 +152,7 @@ describe Toys::StandardMiddleware::ShowHelp do
         desc "beyond all recognition"
         tool "bar" do
           desc "was met"
+          def run; end
         end
       end
     end
@@ -160,6 +167,7 @@ describe Toys::StandardMiddleware::ShowHelp do
         desc "beyond all recognition"
         tool "bar" do
           desc "was met"
+          def run; end
         end
       end
     end

--- a/toys-core/test/test_arg_parser.rb
+++ b/toys-core/test/test_arg_parser.rb
@@ -700,7 +700,7 @@ describe Toys::ArgParser do
     end
 
     it "includes tool suggestions" do
-      tool
+      tool.run_handler = proc { nil }
       root_arg_parser.parse(["fop"])
       root_arg_parser.finish
       assert_errors_include('Tool not found: "fop"', root_arg_parser.errors)

--- a/toys-core/test/test_loader.rb
+++ b/toys-core/test/test_loader.rb
@@ -491,33 +491,41 @@ describe Toys::Loader do
       loader.add_block(source_name: "test block") do
         tool "ns3" do
           tool "tool1" do
+            def run; end
+          end
+          tool "tool4" do
             desc "hi"
           end
           def run; end
         end
         tool "ns2" do
-          desc "hi"
           tool "tool3" do
-            desc "hi"
+            def run; end
           end
           tool "_tool2" do
-            desc "hi"
+            def run; end
           end
         end
         tool "_ns1" do
-          desc "hi"
           tool "tool2" do
-            desc "hi"
+            def run; end
           end
           tool "tool1" do
-            desc "hi"
+            def run; end
           end
+          def run; end
         end
       end
     }
 
     it "loads a list" do
       subtools = subtools_loader.list_subtools([])
+      assert_equal(1, subtools.size)
+      assert_equal(["ns3"], subtools[0].full_name)
+    end
+
+    it "loads a list including non-runnable" do
+      subtools = subtools_loader.list_subtools([], include_namespaces: true)
       assert_equal(2, subtools.size)
       assert_equal(["ns2"], subtools[0].full_name)
       assert_equal(["ns3"], subtools[1].full_name)
@@ -531,25 +539,29 @@ describe Toys::Loader do
       assert_equal(["ns3", "tool1"], subtools[2].full_name)
     end
 
-    it "loads a list including hidden" do
-      subtools = subtools_loader.list_subtools([], include_hidden: true)
-      assert_equal(3, subtools.size)
-      assert_equal(["_ns1"], subtools[0].full_name)
-      assert_equal(["ns2"], subtools[1].full_name)
-      assert_equal(["ns3"], subtools[2].full_name)
+    it "loads a list with recursion including non-runnable" do
+      subtools = subtools_loader.list_subtools([], recursive: true, include_non_runnable: true)
+      assert_equal(4, subtools.size)
+      assert_equal(["ns2", "tool3"], subtools[0].full_name)
+      assert_equal(["ns3"], subtools[1].full_name)
+      assert_equal(["ns3", "tool1"], subtools[2].full_name)
+      assert_equal(["ns3", "tool4"], subtools[3].full_name)
     end
 
-    it "loads a list including hidden with recursion" do
-      subtools = subtools_loader.list_subtools([], recursive: true, include_hidden: true)
-      assert_equal(8, subtools.size)
+    it "loads a list including hidden" do
+      subtools = subtools_loader.list_subtools([], include_hidden: true)
+      assert_equal(2, subtools.size)
       assert_equal(["_ns1"], subtools[0].full_name)
-      assert_equal(["_ns1", "tool1"], subtools[1].full_name)
-      assert_equal(["_ns1", "tool2"], subtools[2].full_name)
-      assert_equal(["ns2"], subtools[3].full_name)
-      assert_equal(["ns2", "_tool2"], subtools[4].full_name)
-      assert_equal(["ns2", "tool3"], subtools[5].full_name)
-      assert_equal(["ns3"], subtools[6].full_name)
-      assert_equal(["ns3", "tool1"], subtools[7].full_name)
+      assert_equal(["ns3"], subtools[1].full_name)
+    end
+
+    it "loads a list including namespaces with recursion" do
+      subtools = subtools_loader.list_subtools([], recursive: true, include_namespaces: true)
+      assert_equal(4, subtools.size)
+      assert_equal(["ns2"], subtools[0].full_name)
+      assert_equal(["ns2", "tool3"], subtools[1].full_name)
+      assert_equal(["ns3"], subtools[2].full_name)
+      assert_equal(["ns3", "tool1"], subtools[3].full_name)
     end
   end
 

--- a/toys-core/test/utils/test_completion_engine.rb
+++ b/toys-core/test/utils/test_completion_engine.rb
@@ -30,9 +30,10 @@ describe Toys::Utils::CompletionEngine do
           complete ["n", "k"], prefix_constraint: /\A([a-z]+=)?\z/
         end
         remaining_args :baz, complete: ["aar", "ooka"]
+        def run; end
       end
       tool "two" do
-        # Empty tool
+        def run; end
       end
       tool "three" do
         tool "four" do
@@ -41,11 +42,12 @@ describe Toys::Utils::CompletionEngine do
           required_arg :foo, complete: tester.context_capture
           optional_arg :bar, complete: tester.context_capture
           remaining_args :baz, complete: tester.context_capture
+          def run; end
         end
       end
       tool "five", delegate_to: ["one"] do
         tool "six" do
-          # Empty tool
+          def run; end
         end
       end
     end

--- a/toys-core/test/utils/test_help_text.rb
+++ b/toys-core/test/utils/test_help_text.rb
@@ -816,9 +816,11 @@ describe Toys::Utils::HelpText do
           tool "foo bar" do
             tool "one" do
               desc "one description"
+              def run; end
             end
             tool "two" do
               desc "two description"
+              def run; end
             end
           end
         end
@@ -826,6 +828,7 @@ describe Toys::Utils::HelpText do
           tool "foo bar" do
             tool "three" do
               desc "three description"
+              def run; end
             end
           end
         end

--- a/toys/.toys/.toys.rb
+++ b/toys/.toys/.toys.rb
@@ -24,15 +24,11 @@ end
 
 tool "test-builtins" do
   include :exec, e: true
+  include :bundler
 
   def run
-    cmd = [
-      "system", "test",
-      "-d", File.join(context_directory, "builtins"),
-      "--minitest-focus",
-      "--minitest-rg"
-    ]
-    exec_tool(cmd)
+    ::Dir.chdir(context_directory)
+    exec_separate_tool(["system", "test", "-d", "builtins", "--minitest-focus", "--minitest-rg"])
   end
 end
 

--- a/toys/builtins/system/.test/test_tools.rb
+++ b/toys/builtins/system/.test/test_tools.rb
@@ -1,0 +1,149 @@
+require "psych"
+require "toys/utils/exec"
+
+describe "toys system tools" do
+  include Toys::Testing
+
+  toys_custom_paths(::File.dirname(::File.dirname(__dir__)))
+  toys_include_builtins(false)
+
+  let(:toys_gem_dir) { ::File.dirname(::File.dirname(::File.dirname(__dir__))) }
+
+  def capture_system_tools_output(cmd, expected_status: 0)
+    out, _err = capture_subprocess_io do
+      status = toys_run_tool(["system", "tools"] + cmd)
+      assert_equal(expected_status, status)
+    end
+    ::Psych.load(out)
+  end
+
+  describe "list" do
+    it "lists tools non-recursively" do
+      result = capture_system_tools_output(["list"])
+      assert_equal("", result["namespace"])
+      system_tool = result["tools"].find { |t| t["name"] == "system" }
+      refute_nil(system_tool)
+      assert_equal("A set of system commands for Toys", system_tool["desc"])
+      refute(system_tool["runnable"])
+    end
+
+    it "lists tools recursively" do
+      result = capture_system_tools_output(["list", "--recursive"])
+      assert_equal("", result["namespace"])
+      system_tool = result["tools"].find { |t| t["name"] == "system" }
+      tools_tool = system_tool["tools"].find { |t| t["name"] == "tools" }
+      assert_equal("Tools that introspect available tools", tools_tool["desc"])
+      refute(tools_tool["runnable"])
+      list_tool = tools_tool["tools"].find { |t| t["name"] == "list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+    end
+
+    it "outputs a flattened list" do
+      result = capture_system_tools_output(["list", "--recursive", "--flatten"])
+      assert_equal("", result["namespace"])
+      list_tool = result["tools"].find { |t| t["name"] == "system tools list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+      system_tool = result["tools"].find { |t| t["name"] == "system" }
+      assert_nil(system_tool)
+    end
+
+    it "shows namespaces when outputting a flattened list with --all" do
+      result = capture_system_tools_output(["list", "--recursive", "--flatten", "--all"])
+      assert_equal("", result["namespace"])
+      list_tool = result["tools"].find { |t| t["name"] == "system tools list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+      system_tool = result["tools"].find { |t| t["name"] == "system" }
+      refute_nil(system_tool)
+      assert_equal("A set of system commands for Toys", system_tool["desc"])
+      refute(system_tool["runnable"])
+    end
+
+    it "lists tools recursively under a namespace" do
+      result = capture_system_tools_output(["list", "--recursive", "system"])
+      assert_equal("system", result["namespace"])
+      tools_tool = result["tools"].find { |t| t["name"] == "tools" }
+      assert_equal("Tools that introspect available tools", tools_tool["desc"])
+      refute(tools_tool["runnable"])
+      list_tool = tools_tool["tools"].find { |t| t["name"] == "list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+    end
+
+    it "recognizes deeper namespaces delimited by spaces" do
+      result = capture_system_tools_output(["list", "--recursive", "system", "tools"])
+      assert_equal("system tools", result["namespace"])
+      list_tool = result["tools"].find { |t| t["name"] == "list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+    end
+
+    it "recognizes deeper namespaces delimited by dots" do
+      result = capture_system_tools_output(["list", "--recursive", "system.tools"])
+      assert_equal("system tools", result["namespace"])
+      list_tool = result["tools"].find { |t| t["name"] == "list" }
+      assert_equal("Output a list of the tools under the given namespace.", list_tool["desc"])
+      assert(list_tool["runnable"])
+    end
+
+    it "lists only local tools from a directory" do
+      result = capture_system_tools_output(["list", "--recursive", "--local", "--dir", toys_gem_dir])
+      assert_equal("", result["namespace"])
+      system_tool = result["tools"].find { |t| t["name"] == "system" }
+      assert_nil(system_tool)
+      ci_tool = result["tools"].find { |t| t["name"] == "ci" }
+      assert_equal("Run all CI checks", ci_tool["desc"])
+      assert(ci_tool["runnable"])
+    end
+  end
+
+  describe "show" do
+    it "shows a runnable tool" do
+      result = capture_system_tools_output(["show", "system", "tools", "list"])
+      assert_equal("system tools list", result["name"])
+      assert_equal("Output a list of the tools under the given namespace.", result["desc"])
+      assert(result["runnable"])
+      assert(result["exists"])
+    end
+
+    it "shows a runnable tool specified using dots" do
+      result = capture_system_tools_output(["show", "system.tools.list"])
+      assert_equal("system tools list", result["name"])
+      assert_equal("Output a list of the tools under the given namespace.", result["desc"])
+      assert(result["runnable"])
+      assert(result["exists"])
+    end
+
+    it "shows a namespace" do
+      result = capture_system_tools_output(["show", "system", "tools"])
+      assert_equal("system tools", result["name"])
+      assert_equal("Tools that introspect available tools", result["desc"])
+      refute(result["runnable"])
+      assert(result["exists"])
+    end
+
+    it "shows a nonexistent tool" do
+      result = capture_system_tools_output(["show", "system", "tools", "blahblah"], expected_status: 1)
+      assert_equal("system tools blahblah", result["name"])
+      refute_includes(result, "desc")
+      refute(result["exists"])
+    end
+
+    it "shows a local tool from a directory" do
+      result = capture_system_tools_output(["show", "--local", "--dir", toys_gem_dir, "ci"])
+      assert_equal("ci", result["name"])
+      assert_equal("Run all CI checks", result["desc"])
+      assert(result["runnable"])
+      assert(result["exists"])
+    end
+
+    it "omits tools not found in a local directory" do
+      result = capture_system_tools_output(["show", "--local", "--dir", toys_gem_dir, "system"], expected_status: 1)
+      assert_equal("system", result["name"])
+      refute_includes(result, "desc")
+      refute(result["exists"])
+    end
+  end
+end

--- a/toys/builtins/system/test.rb
+++ b/toys/builtins/system/test.rb
@@ -30,7 +30,6 @@ include :terminal
 
 def run
   load_minitest_gems
-  ::Dir.chdir(tool_dir)
   test_files = find_test_files
   result = exec_ruby(ruby_args, in: :controller, log_cmd: "Starting minitest...") do |controller|
     controller.in.puts("gem 'minitest', '= #{::Minitest::VERSION}'")
@@ -43,7 +42,6 @@ def run
       controller.in.puts("gem 'minitest-rg', '= #{::MiniTest::RG::VERSION}'")
       controller.in.puts("require 'minitest/rg'")
     end
-    controller.in.puts("gem 'toys', '= #{::Toys::VERSION}'")
     controller.in.puts("require 'toys'")
     controller.in.puts("require 'toys/testing'")
     if directory
@@ -79,7 +77,8 @@ end
 def find_test_files
   glob = ".test/**/test_*.rb"
   glob = "**/#{glob}" if recursive
-  test_files = ::Dir.glob(glob)
+  glob = "#{tool_dir}/#{glob}"
+  test_files = Dir.glob(glob)
   if test_files.empty?
     logger.warn("No test files found")
     exit

--- a/toys/builtins/system/tools.rb
+++ b/toys/builtins/system/tools.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+mixin "tool-methods" do
+  def format_tool(tool, namespace, detailed: false)
+    output = {
+      "name" => tool.full_name[namespace.length..-1].join(" "),
+      "desc" => tool.desc.to_s,
+      "runnable" => tool.runnable?,
+    }
+    if detailed
+      output["exists"] = true
+      output["long_desc"] = tool.long_desc.map(&:to_s)
+    end
+    output
+  end
+
+  def choose_loader(local, from_dir)
+    return cli.loader unless local || from_dir
+    special_cli = if local
+                    cli.child.add_search_path(from_dir || ::Dir.getwd)
+                  else
+                    ::Toys::StandardCLI.new(cur_dir: from_dir)
+                  end
+    special_cli.loader
+  end
+end
+
+desc "Tools that introspect available tools"
+
+long_desc \
+  "Tools that introspect the available tools."
+
+tool "list" do
+  desc "Output a list of the tools under the given namespace."
+
+  long_desc \
+    "Outputs a list of the tools under the given namespace, in YAML format, to the standard " \
+      "output stream."
+
+  remaining_args :namespace
+
+  flag :local do
+    desc "List only tools defined locally in the current directory."
+  end
+  flag :recursive, "--[no-]recursive" do
+    desc "Recursively list subtools"
+  end
+  flag :flatten, "--[no-]flatten" do
+    desc "Display a flattened list of tools"
+  end
+  flag :from_dir, "--dir=PATH" do
+    desc "List tools from the given directory."
+  end
+  flag :show_all, "--all" do
+    desc "Show all tools, including hidden tools and non-runnable namespaces"
+  end
+
+  include "tool-methods"
+
+  def run
+    require "psych"
+    loader = choose_loader(local, from_dir)
+    words = namespace
+    words = loader.split_path(words.first) if words.size == 1
+    tool_list = loader.list_subtools(words,
+                                     recursive: recursive,
+                                     include_hidden: show_all,
+                                     include_namespaces: show_all || !flatten,
+                                     include_non_runnable: show_all)
+    output = {
+      "namespace" => words.join(" "),
+      "tools" => [],
+    }
+    if flatten
+      output["tools"] = tool_list.map { |tool| format_tool(tool, words) }
+    else
+      format_tool_list(tool_list, output, words)
+    end
+    puts(::Psych.dump(output))
+  end
+
+  def format_tool_list(tool_list, toplevel, cur_ns)
+    stack = [toplevel]
+    tool_list.each do |tool|
+      tool_name_size = tool.full_name.size
+      while cur_ns.size >= tool_name_size
+        stack.pop
+        cur_ns.pop
+      end
+      formatted = format_tool(tool, cur_ns)
+      (stack.last["tools"] ||= []) << formatted
+      stack.push(formatted)
+      cur_ns.push(tool.full_name.last)
+    end
+  end
+end
+
+tool "show" do
+  desc "Show detailed information about a single tool"
+
+  long_desc \
+    "Outputs details about the given tool, in YAML format, to the standard output stream."
+
+  remaining_args :name
+
+  flag :local do
+    desc "Show only tools defined locally in the current directory."
+  end
+  flag :from_dir, "--dir=PATH" do
+    desc "Show a tool accessible from the given directory."
+  end
+
+  include "tool-methods"
+
+  def run
+    require "psych"
+    loader = choose_loader(local, from_dir)
+    words = name
+    words = loader.split_path(words.first) if words.size == 1
+    tool = loader.lookup_specific(words)
+    output =
+      if tool.nil?
+        {
+          "name" => words.join(" "),
+          "exists" => false,
+        }
+      else
+        format_tool(tool, [], detailed: true)
+      end
+    puts(::Psych.dump(output))
+    exit(tool.nil? ? 1 : 0)
+  end
+end

--- a/toys/lib/toys/testing.rb
+++ b/toys/lib/toys/testing.rb
@@ -94,6 +94,37 @@ module Toys
     # @param cmd [String,Array<String>] The command to execute.
     # @return [Integer] The integer result code (i.e. 0 for success).
     #
+    # @example
+    #   # Given the following tool:
+    #
+    #   tool "hello" do
+    #     flag :shout
+    #     def run
+    #       puts message
+    #     end
+    #     def message
+    #       shout ? "HELLO" : "hello"
+    #     end
+    #   end
+    #
+    #   # You can test the tool's output as follows:
+    #
+    #   class MyTest < Minitest::Test
+    #     include Toys::Testing
+    #     def test_output_without_shout
+    #       assert_output("hello\n") do
+    #         result = toys_run_tool(["hello"])
+    #         assert_equal(0, result)
+    #       end
+    #     end
+    #     def test_with_shout
+    #       assert_output("HELLO\n") do
+    #         result = toys_run_tool(["hello", "--shout"])
+    #         assert_equal(0, result)
+    #       end
+    #     end
+    #   end
+    #
     def toys_run_tool(cmd, cli: nil)
       cli ||= toys_cli
       cmd = ::Shellwords.split(cmd) if cmd.is_a?(::String)
@@ -146,11 +177,11 @@ module Toys
     #     include Toys::Testing
     #     def test_output_without_shout
     #       result = toys_exec_tool(["hello"])
-    #       assert_equal("hello hello\n", result.captured_out)
+    #       assert_equal("hello\n", result.captured_out)
     #     end
     #     def test_with_shout
     #       result = toys_exec_tool(["hello", "--shout"])
-    #       assert_equal("HELLO HELLO\n", result.captured_out)
+    #       assert_equal("HELLO\n", result.captured_out)
     #     end
     #   end
     #


### PR DESCRIPTION
Also includes a bunch of additional fixes:

* Removed some potential deadlocks if Loader is accessed from multiple threads
* Loader#list_subtools takes separate arguments for filtering namespaces and non-runnable tools
* The system test builtin no longer requires toys to be installed as a gem
* Fixed a failure when passing a relative path to system test --directory