### PR TITLE
Add individual released gems info into commit message.

### DIFF
--- a/.toys/release/.lib/release_requester.rb
+++ b/.toys/release/.lib/release_requester.rb
@@ -345,7 +345,12 @@ class ReleaseRequester
       @release_commit_title = "release: Release #{info.gem_name} #{info.new_version}"
       @release_branch_name = @utils.release_branch_name(info.gem_name)
     else
-      @release_commit_title = "release: Release #{@gem_info_list.size} gems"
+      @release_commit_title = "release: Release #{@gem_info_list.size} gems\n\n"
+      @gem_info_list.each do |info|
+        gem_line = " *  **#{info.gem_name} #{info.new_version}**"
+        gem_line += info.last_version ? " (was #{info.last_version})" : " (initial release)"
+        @release_commit_title += gem_line + "\n"
+      end
       @release_branch_name = @utils.multi_release_branch_name
     end
   end


### PR DESCRIPTION
:wave: 

Hello, this is naive approach to implement an idea of adding also gem release info into multi release commit message.

## motivation

In recent weeks I was trying to get familiar with [opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby) and often I have seen commits like https://github.com/open-telemetry/opentelemetry-ruby/pull/1523/commits/a7bd62a59cbca73093dd1655c9e2065cd047447a. It is not possible to find out what was released looking just at commit message. For me, it would be super helpful to include this info as part of commit message.