### PR TITLE
release: Release 2 gems

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -8,7 +8,7 @@ jobs:
   release-process-request:
     if: ${{ github.repository == 'dazuma/toys' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -16,7 +16,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Process release request

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -9,7 +9,7 @@ jobs:
   release-update-open-requests:
     if: ${{ github.repository == 'dazuma/toys' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -17,7 +17,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Update open releases

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -18,7 +18,7 @@ jobs:
   release-perform:
     if: ${{ github.repository == 'dazuma/toys' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Perform release

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -12,7 +12,7 @@ jobs:
   release-request:
     if: ${{ github.repository == 'dazuma/toys' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -20,7 +20,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Open release pull request

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -15,7 +15,7 @@ jobs:
   release-retry:
     if: ${{ github.repository == 'dazuma/toys' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -23,7 +23,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Retry release

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -8,6 +8,16 @@ required_checks_timeout: 1800
 commit_lint:
   fail_checks: true
   merge: squash
+release_commit_tags:
+  - tag: feat
+    semver: minor
+    label: ADDED
+  - tag: fix
+    label: FIXED
+  - docs
+  - tests: patch
+required_checks: false
+
 gems:
   - name: toys-core
     version_rb_path: lib/toys/core.rb

--- a/.toys/release/.data/templates/release-hook-on-closed.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-closed.yml.erb
@@ -8,7 +8,7 @@ jobs:
   release-process-request:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -16,7 +16,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Process release request

--- a/.toys/release/.data/templates/release-hook-on-open.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-open.yml.erb
@@ -8,7 +8,7 @@ jobs:
   release-check-commits:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -16,7 +16,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Install Toys

--- a/.toys/release/.data/templates/release-hook-on-push.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-push.yml.erb
@@ -9,7 +9,7 @@ jobs:
   release-update-open-requests:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -17,7 +17,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Update open releases

--- a/.toys/release/.data/templates/release-perform.yml.erb
+++ b/.toys/release/.data/templates/release-perform.yml.erb
@@ -18,7 +18,7 @@ jobs:
   release-perform:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Perform release

--- a/.toys/release/.data/templates/release-request.yml.erb
+++ b/.toys/release/.data/templates/release-request.yml.erb
@@ -12,7 +12,7 @@ jobs:
   release-request:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -20,7 +20,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Open release pull request

--- a/.toys/release/.data/templates/release-retry.yml.erb
+++ b/.toys/release/.data/templates/release-retry.yml.erb
@@ -15,7 +15,7 @@ jobs:
   release-retry:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.2"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
@@ -23,7 +23,7 @@ jobs:
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Retry release

--- a/.toys/release/.lib/release_utils.rb
+++ b/.toys/release/.lib/release_utils.rb
@@ -38,7 +38,8 @@ class ReleaseUtils
                  :signoff_commits?, :enable_release_automation?, :coordinate_versions?
   def_delegators :@repo_settings,
                  :commit_lint_active?, :commit_lint_fail_checks?,
-                 :commit_lint_merge, :commit_lint_allowed_types
+                 :commit_lint_merge, :commit_lint_allowed_types,
+                 :release_commit_tags
   def_delegators :@repo_settings,
                  :all_gems, :gem_info,
                  :gem_directory, :gem_cd,

--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### v0.15.0 / 2023-09-23
+
+* BREAKING CHANGE: Overhaul of the CLI standard error handling
+
+* ADDED: Overhaul of the CLI standard error handling
+* DOCS: Various documentation fixes and clarifications
+
 ### v0.14.7 / 2023-07-19
 
 * FIXED: Fixed an exception when passing a non-string to puts in the terminal mixin

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.14.7"
+    VERSION = "0.15.0"
   end
 
   ##

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### v0.15.0 / 2023-09-23
+
+* BREAKING CHANGE: Overhaul of the CLI standard error handling
+
+* ADDED: Overhaul of the CLI standard error handling
+* DOCS: Various documentation fixes and clarifications
+
 ### v0.14.7 / 2023-07-19
 
 * FIXED: Fixed an exception when passing a non-string to puts in the terminal mixin

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.14.7"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **toys-core 0.15.0** (was 0.14.7)
 *  **toys 0.15.0** (was 0.14.7)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the     "release: pending" label is set. The release     script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-core

### v0.15.0 / 2023-09-23

* BREAKING CHANGE: Overhaul of the CLI standard error handling

* ADDED: Overhaul of the CLI standard error handling
* DOCS: Various documentation fixes and clarifications

----

## toys

### v0.15.0 / 2023-09-23

* BREAKING CHANGE: Overhaul of the CLI standard error handling

* ADDED: Overhaul of the CLI standard error handling
* DOCS: Various documentation fixes and clarifications
