### PR TITLE
fix: Allow tests and specs to interact with stdin

### DIFF
--- a/toys-dev
+++ b/toys-dev
@@ -4,4 +4,5 @@ dir=$(cd `dirname $0` && pwd)
 export TOYS_DEV=true
 export TOYS_LIB_PATH="$dir/toys/lib"
 export TOYS_CORE_LIB_PATH="$dir/toys-core/lib"
-exec ruby --disable=gems "$dir/toys/bin/toys" "$@"
+export TOYS_BIN_PATH="$dir/toys/bin/toys"
+exec ruby --disable=gems "$TOYS_BIN_PATH" "$@"

--- a/toys/.rubocop.yml
+++ b/toys/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: "../.rubocop-common.yml"
 AllCops:
   Exclude:
     - "test/rubocop-cases/**/*"
+    - "test/rspec-cases/**/*"
     - "core-docs/**/*"
 Layout/LineLength:
   Exclude:

--- a/toys/lib/toys.rb
+++ b/toys/lib/toys.rb
@@ -8,6 +8,7 @@ require "toys/version"
 # don't get clobbered in case someone sets up bundler later.
 unless ::ENV.key?("TOYS_CORE_LIB_PATH")
   path = ::File.expand_path("../../toys-core-#{::Toys::VERSION}/lib", __dir__)
+  path = ::File.expand_path("../../toys-core/lib", __dir__) unless path && ::File.directory?(path)
   unless path && ::File.directory?(path)
     require "rubygems"
     dep = ::Gem::Dependency.new("toys-core", "= #{::Toys::VERSION}")

--- a/toys/lib/toys/templates/rdoc.rb
+++ b/toys/lib/toys/templates/rdoc.rb
@@ -322,11 +322,12 @@ module Toys
               args << "-T" << template.template if template.template
               args << "-f" << template.generator if template.generator
 
-              exec_ruby([], in: :controller) do |controller|
-                controller.in.puts("gem 'rdoc', *#{gem_requirements.inspect}")
-                controller.in.puts("require 'rdoc'")
-                controller.in.puts("::RDoc::RDoc.new.document(#{(args + files).inspect})")
-              end
+              code = <<~CODE
+                gem 'rdoc', *#{gem_requirements.inspect}
+                require 'rdoc'
+                ::RDoc::RDoc.new.document(#{(args + files).inspect})
+              CODE
+              exec_ruby(["-e", code])
             end
           end
         end

--- a/toys/lib/toys/templates/rubocop.rb
+++ b/toys/lib/toys/templates/rubocop.rb
@@ -184,11 +184,12 @@ module Toys
 
             ::Dir.chdir(context_directory || ::Dir.getwd) do
               logger.info "Running RuboCop..."
-              result = exec_ruby([], in: :controller) do |controller|
-                controller.in.puts("gem 'rubocop', *#{template.gem_version.inspect}")
-                controller.in.puts("require 'rubocop'")
-                controller.in.puts("exit(::RuboCop::CLI.new.run(#{template.options.inspect}))")
-              end
+              code = <<~CODE
+                gem 'rubocop', *#{template.gem_version.inspect}
+                require 'rubocop'
+                exit(::RuboCop::CLI.new.run(#{template.options.inspect}))
+              CODE
+              result = exec_ruby(["-e", code])
               if result.error?
                 logger.error "RuboCop failed!"
                 exit(1) if template.fail_on_error

--- a/toys/lib/toys/templates/yardoc.rb
+++ b/toys/lib/toys/templates/yardoc.rb
@@ -503,21 +503,23 @@ module Toys
               end
               run_options.concat(files)
 
-              result = exec_ruby([], in: :controller) do |controller|
-                controller.in.puts("gem 'yard', *#{gem_requirements.inspect}")
-                controller.in.puts("require 'yard'")
-                controller.in.puts("::YARD::CLI::Yardoc.run(*#{run_options.inspect})")
-              end
+              code = <<~CODE
+                gem 'yard', *#{gem_requirements.inspect}
+                require 'yard'
+                ::YARD::CLI::Yardoc.run(*#{run_options.inspect})
+              CODE
+              result = exec_ruby(["-e", code])
               if result.error?
                 puts("Yardoc encountered errors", :red, :bold) unless verbosity.negative?
                 exit(1)
               end
               unless stats_options.empty?
-                result = exec_ruby([], in: :controller, out: :capture) do |controller|
-                  controller.in.puts("gem 'yard', *#{gem_requirements.inspect}")
-                  controller.in.puts("require 'yard'")
-                  controller.in.puts("::YARD::CLI::Stats.run(*#{stats_options.inspect})")
-                end
+                code = <<~CODE
+                  gem 'yard', *#{gem_requirements.inspect}
+                  require 'yard'
+                  ::YARD::CLI::Stats.run(*#{stats_options.inspect})
+                CODE
+                result = exec_ruby(["-e", code], out: :capture)
                 puts result.captured_out
                 if result.error?
                   puts("Yardoc encountered errors", :red, :bold) unless verbosity.negative?

--- a/toys/test/minitest-cases/stream/.toys.rb
+++ b/toys/test/minitest-cases/stream/.toys.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+truncate_load_path!
+
+expand :minitest, files: "foo.rb"

--- a/toys/test/minitest-cases/stream/foo.rb
+++ b/toys/test/minitest-cases/stream/foo.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+describe "foo" do
+  it "reads hello" do
+    assert_equal("hello\n", $stdin.read)
+  end
+end

--- a/toys/test/rspec-cases/lib1/spec_fixture.rb
+++ b/toys/test/rspec-cases/lib1/spec_fixture.rb
@@ -2,6 +2,6 @@
 
 module SpecFixture
   def self.foo
-    :foo
+    "foo"
   end
 end

--- a/toys/test/rspec-cases/lib2/spec_fixture.rb
+++ b/toys/test/rspec-cases/lib2/spec_fixture.rb
@@ -2,6 +2,6 @@
 
 module SpecFixture
   def self.foo
-    :bar
+    "bar"
   end
 end

--- a/toys/test/rspec-cases/spec/my_spec.rb
+++ b/toys/test/rspec-cases/spec/my_spec.rb
@@ -4,6 +4,6 @@ require "spec_fixture"
 
 describe SpecFixture do
   it "returns foo" do
-    expect(SpecFixture.foo).to eql(:foo)
+    expect(SpecFixture.foo).to eql("foo")
   end
 end

--- a/toys/test/rspec-cases/stream/.toys.rb
+++ b/toys/test/rspec-cases/stream/.toys.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+truncate_load_path!
+
+expand :rspec, pattern: "*_spec.rb"

--- a/toys/test/rspec-cases/stream/my_spec.rb
+++ b/toys/test/rspec-cases/stream/my_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "streams" do
+  it "returns foo" do
+    expect($stdin.read.strip).to eql("foo")
+  end
+end

--- a/toys/test/test_minitest.rb
+++ b/toys/test/test_minitest.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "helper"
+require "toys/utils/exec"
 
 describe "minitest template" do
   let(:template_lookup) { Toys::ModuleLookup.new.add_path("toys/templates") }
@@ -128,6 +129,7 @@ describe "minitest template" do
     let(:cli) { Toys::CLI.new(middleware_stack: [], template_lookup: template_lookup) }
     let(:loader) { cli.loader }
     let(:cases_dir) { File.join(__dir__, "minitest-cases") }
+    let(:exec_service) { Toys::Utils::Exec.new }
 
     it "runs passing tests" do
       dir = cases_dir
@@ -162,6 +164,18 @@ describe "minitest template" do
         assert_equal(1, cli.run("test"))
       end
       assert_match(/1 failure/, out)
+    end
+
+    it "supports input streams" do
+      dir = "#{cases_dir}/stream"
+      args = ["--disable=gems", Toys.executable_path, "test"]
+      result = exec_service.exec_ruby(args, chdir: dir,
+                                      in: :controller, out: :capture) do |controller|
+        controller.in.puts "hello"
+      end
+      assert(result.success?)
+      assert_match(/0 failures/, result.captured_out)
+      assert_match(/0 errors/, result.captured_out)
     end
   end
 end


### PR DESCRIPTION
Standard template-based tools that spawn Ruby processes provide the code as command line arguments rather than via the input stream. Affected templates are `:minitest`, `:rdoc`, `:rspec`, `:rubocop`, and `:yardoc`. This should allow those tools to interact with stdin properly—for example, someone invoking pry from a test.

Fixes #231
