### PR TITLE
fix: Clean up some requires

### DIFF
--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "rbconfig"
-require "logger"
-require "toys/completion"
-
 module Toys
   ##
   # A Toys-based CLI.
@@ -566,6 +562,7 @@ module Toys
       # @return [Proc]
       #
       def default_logger_factory
+        require "logger"
         proc do
           logger = ::Logger.new($stderr)
           logger.level = ::Logger::WARN

--- a/toys-core/lib/toys/loader.rb
+++ b/toys-core/lib/toys/loader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "monitor"
-
 module Toys
   ##
   # The Loader service loads tools from configuration files, and finds the
@@ -55,6 +53,7 @@ module Toys
       if index_file_name && ::File.extname(index_file_name) != ".rb"
         raise ::ArgumentError, "Illegal index file name #{index_file_name.inspect}"
       end
+      require "monitor"
       @mutex = ::Monitor.new
       @mixin_lookup = mixin_lookup || ModuleLookup.new
       @template_lookup = template_lookup || ModuleLookup.new
@@ -477,7 +476,7 @@ module Toys
       end
     end
 
-    @git_cache_mutex = ::Monitor.new
+    @git_cache_mutex = ::Mutex.new
     @default_git_cache = nil
 
     ##

--- a/toys-core/lib/toys/module_lookup.rb
+++ b/toys-core/lib/toys/module_lookup.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "monitor"
-
 module Toys
   ##
   # A helper module that provides methods to do module lookups. This is
@@ -56,6 +54,7 @@ module Toys
     # Create an empty ModuleLookup
     #
     def initialize
+      require "monitor"
       @mutex = ::Monitor.new
       @paths = []
       @paths_locked = false

--- a/toys-core/lib/toys/settings.rb
+++ b/toys-core/lib/toys/settings.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "date"
-
 module Toys
   ##
   # A settings class defines the structure of application settings, i.e. the
@@ -488,7 +486,7 @@ module Toys
         def convert(val, klass)
           return val if val.is_a?(klass)
           begin
-            CONVERTERS[klass].call(val)
+            CONVERTERS[klass.name].call(val)
           rescue ::StandardError
             ILLEGAL_VALUE
           end
@@ -564,13 +562,13 @@ module Toys
       # @private
       #
       CONVERTERS = {
-        ::Date => date_converter,
-        ::DateTime => datetime_converter,
-        ::Float => float_converter,
-        ::Integer => integer_converter,
-        ::Regexp => regexp_converter,
-        ::Symbol => symbol_converter,
-        ::Time => time_converter,
+        "Date" => date_converter,
+        "DateTime" => datetime_converter,
+        "Float" => float_converter,
+        "Integer" => integer_converter,
+        "Regexp" => regexp_converter,
+        "Symbol" => symbol_converter,
+        "Time" => time_converter,
       }.freeze
     end
 

--- a/toys-core/lib/toys/standard_middleware/show_help.rb
+++ b/toys-core/lib/toys/standard_middleware/show_help.rb
@@ -248,8 +248,10 @@ module Toys
       private
 
       def terminal
-        require "toys/utils/terminal"
-        @terminal ||= Utils::Terminal.new(output: @stream, styled: @styled_output)
+        @terminal ||= begin
+          require "toys/utils/terminal"
+          Utils::Terminal.new(output: @stream, styled: @styled_output)
+        end
       end
 
       def show_usage(context)

--- a/toys-core/lib/toys/standard_mixins/exec.rb
+++ b/toys-core/lib/toys/standard_mixins/exec.rb
@@ -830,6 +830,8 @@ module Toys
       end
 
       on_initialize do |**opts|
+        require "rbconfig"
+        require "shellwords"
         require "toys/utils/exec"
         context = self
         opts = Exec._setup_exec_opts(opts, context)

--- a/toys-core/lib/toys/standard_mixins/fileutils.rb
+++ b/toys-core/lib/toys/standard_mixins/fileutils.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
 module Toys
   module StandardMixins
     ##
@@ -20,6 +18,7 @@ module Toys
       # @private
       #
       def self.included(mod)
+        require "fileutils"
         mod.include(::FileUtils)
       end
     end

--- a/toys-core/lib/toys/standard_mixins/gems.rb
+++ b/toys-core/lib/toys/standard_mixins/gems.rb
@@ -65,9 +65,11 @@ module Toys
         # @private
         #
         def self.gems
-          require "toys/utils/gems"
           # rubocop:disable Naming/MemoizedInstanceVariableName
-          @__gems ||= Utils::Gems.new(**@__gems_opts)
+          @__gems ||= begin
+            require "toys/utils/gems"
+            Utils::Gems.new(**@__gems_opts)
+          end
           # rubocop:enable Naming/MemoizedInstanceVariableName
         end
 

--- a/toys-core/lib/toys/standard_mixins/highline.rb
+++ b/toys-core/lib/toys/standard_mixins/highline.rb
@@ -131,7 +131,7 @@ module Toys
 
       on_initialize do |*args|
         require "toys/utils/gems"
-        Toys::Utils::Gems.activate("highline", "~> 2.0")
+        ::Toys::Utils::Gems.activate("highline", "~> 2.0")
         require "highline"
         self[KEY] = ::HighLine.new(*args)
         self[KEY].use_color = $stdout.tty?

--- a/toys-core/lib/toys/standard_mixins/xdg.rb
+++ b/toys-core/lib/toys/standard_mixins/xdg.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
 module Toys
   module StandardMixins
     ##

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 module Toys
   ##
   # A ToolDefinition describes a single command that can be invoked using Toys.
@@ -284,7 +282,7 @@ module Toys
     ##
     # Settings for this tool
     #
-    # @return [Toys::Tool::Settings]
+    # @return [Toys::ToolDefinition::Settings]
     #
     attr_reader :settings
 

--- a/toys-core/lib/toys/utils/completion_engine.rb
+++ b/toys-core/lib/toys/utils/completion_engine.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "shellwords"
-
 module Toys
   module Utils
     ##
@@ -21,6 +19,7 @@ module Toys
         # @param cli [Toys::CLI] The CLI.
         #
         def initialize(cli)
+          require "shellwords"
           @cli = cli
         end
 

--- a/toys-core/lib/toys/utils/exec.rb
+++ b/toys-core/lib/toys/utils/exec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "rbconfig"
-require "logger"
-require "shellwords"
-
 module Toys
   module Utils
     ##
@@ -266,6 +262,9 @@ module Toys
       #     for a description of the options.
       #
       def initialize(**opts, &block)
+        require "rbconfig"
+        require "logger"
+        require "stringio"
         @default_opts = Opts.new(&block).add(opts)
       end
 

--- a/toys-core/lib/toys/utils/gems.rb
+++ b/toys-core/lib/toys/utils/gems.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "monitor"
-require "rubygems"
 
 module Toys
   module Utils
@@ -123,6 +122,7 @@ module Toys
                      output: nil,
                      suppress_confirm: nil,
                      default_confirm: nil)
+        require "rubygems"
         @default_confirm = default_confirm || default_confirm.nil? ? true : false
         @on_missing = on_missing ||
                       if suppress_confirm

--- a/toys-core/lib/toys/utils/git_cache.rb
+++ b/toys-core/lib/toys/utils/git_cache.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
-require "fileutils"
-require "json"
-require "toys/compat"
-require "toys/utils/exec"
-require "toys/utils/xdg"
-
 module Toys
   module Utils
     ##
@@ -288,6 +281,11 @@ module Toys
       #     a specific directory in the user's XDG cache.
       #
       def initialize(cache_dir: nil)
+        require "digest"
+        require "fileutils"
+        require "json"
+        require "toys/compat"
+        require "toys/utils/exec"
         @cache_dir = ::File.expand_path(cache_dir || default_cache_dir)
         @exec = Utils::Exec.new(out: :capture, err: :capture)
       end
@@ -485,6 +483,7 @@ module Toys
       end
 
       def default_cache_dir
+        require "toys/utils/xdg"
         ::File.join(XDG.new.cache_home, "toys", "git")
       end
 

--- a/toys-core/lib/toys/utils/help_text.rb
+++ b/toys-core/lib/toys/utils/help_text.rb
@@ -351,6 +351,7 @@ module Toys
         def initialize(tool, executable_name, delegates, subtools, search_term,
                        show_source_path, separate_sources, indent, indent2, wrap_width, styled)
           require "toys/utils/terminal"
+          require "stringio"
           @tool = tool
           @executable_name = executable_name
           @delegates = delegates
@@ -667,6 +668,7 @@ module Toys
         def initialize(tool, subtools, recursive, search_term, separate_sources,
                        indent, wrap_width, styled)
           require "toys/utils/terminal"
+          require "stringio"
           @tool = tool
           @subtools = subtools
           @recursive = recursive

--- a/toys-core/lib/toys/utils/pager.rb
+++ b/toys-core/lib/toys/utils/pager.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "toys/utils/exec"
-
 module Toys
   module Utils
     ##
@@ -150,7 +148,10 @@ module Toys
         # @private
         #
         def default_exec_service
-          @default_exec_service ||= Exec.new
+          @default_exec_service ||= begin
+            require "toys/utils/exec"
+            Utils::Exec.new
+          end
         end
       end
     end

--- a/toys-core/lib/toys/utils/standard_ui.rb
+++ b/toys-core/lib/toys/utils/standard_ui.rb
@@ -28,8 +28,9 @@ module Toys
       #     terminal output. Default is `$stderr`.
       #
       def initialize(output: nil)
-        @terminal = output || $stderr
+        require "logger"
         require "toys/utils/terminal"
+        @terminal = output || $stderr
         @terminal = Terminal.new(output: @terminal) unless @terminal.is_a?(Terminal)
         @log_header_severity_styles = {
           "FATAL" => [:bright_magenta, :bold, :underline],

--- a/toys-core/lib/toys/utils/terminal.rb
+++ b/toys-core/lib/toys/utils/terminal.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "stringio"
-require "monitor"
-
 begin
   require "io/console"
 rescue ::LoadError
@@ -116,6 +113,7 @@ module Toys
       #     setting is inferred from whether the output has a tty.
       #
       def initialize(input: $stdin, output: $stdout, styled: nil)
+        require "monitor"
         @input = input
         @output = output
         @styled =

--- a/toys-core/lib/toys/utils/xdg.rb
+++ b/toys-core/lib/toys/utils/xdg.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "toys/compat"
-
 module Toys
   module Utils
     ##
@@ -50,6 +48,8 @@ module Toys
       #     you can omit this argument, as it will default to `::ENV`.
       #
       def initialize(env: ::ENV)
+        require "fileutils"
+        require "toys/compat"
         @env = env
       end
 

--- a/toys-core/test/test_dsl.rb
+++ b/toys-core/test/test_dsl.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "helper"
+require "logger"
+require "stringio"
 
 describe Toys::DSL::Tool do
   let(:logger) {

--- a/toys-core/test/utils/test_git_cache.rb
+++ b/toys-core/test/utils/test_git_cache.rb
@@ -3,6 +3,7 @@
 require "helper"
 require "toys/utils/exec"
 require "toys/utils/git_cache"
+require "digest"
 require "fileutils"
 require "net/http"
 require "uri"

--- a/toys/builtins/system/.test/test_git_cache.rb
+++ b/toys/builtins/system/.test/test_git_cache.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+require "json"
 require "psych"
 require "toys/utils/exec"
 require "toys/utils/git_cache"

--- a/toys/builtins/system/.test/test_tools.rb
+++ b/toys/builtins/system/.test/test_tools.rb
@@ -1,3 +1,4 @@
+require "json"
 require "psych"
 require "toys/utils/exec"
 

--- a/toys/lib/toys/templates/rake.rb
+++ b/toys/lib/toys/templates/rake.rb
@@ -164,12 +164,12 @@ module Toys
         gem "rake", *template.gem_version
         require "rake"
 
-        rakefile_path = Templates::Rake.find_rakefile(
+        rakefile_path = ::Toys::Templates::Rake.find_rakefile(
           template.rakefile_path, template.context_directory || context_directory
         )
         raise "Cannot find #{template.rakefile_path}" unless rakefile_path
         rake_context_dir = ::File.dirname(rakefile_path)
-        rake = Templates::Rake.prepare_rake(rakefile_path, rake_context_dir)
+        rake = ::Toys::Templates::Rake.prepare_rake(rakefile_path, rake_context_dir)
 
         rake.tasks.each do |task|
           comments = task.full_comment.to_s.split("\n")
@@ -190,7 +190,7 @@ module Toys
 
             if template.use_flags
               task.arg_names.each do |arg|
-                specs = Templates::Rake.flag_specs(arg)
+                specs = ::Toys::Templates::Rake.flag_specs(arg)
                 flag(arg, *specs) unless specs.empty?
               end
 


### PR DESCRIPTION
Went through and made sure requires are correct and in the right places. Also eliminated a few requires that weren't strictly necessary, and deferred a few others into major object constructors so they don't show up in bundles unless absolutely necessary. Among the changes, Toys no longer eagerly requires `stringio`, allowing a subsequent bundle to control it, which may help alleviate #240.