### PR TITLE
fix: Minitest template defers calling autorun until after tests are loaded

### DIFF
--- a/toys/lib/toys/templates/minitest.rb
+++ b/toys/lib/toys/templates/minitest.rb
@@ -305,7 +305,7 @@ module Toys
                 end
                 tests.uniq!
               end
-              code = ["require 'minitest/autorun'"] + tests.map { |file| "load '#{file}'" }
+              code = tests.map { |file| "load '#{file}'" } + ["require 'minitest/autorun'"]
               ruby_args << "-e" << code.join("\n")
 
               ruby_args << "--"


### PR DESCRIPTION
This should alleviate the stringio "redefinition" warnings when running Rails tests without bundler (#245). The warnings happen if the built-in stringio is loaded before a bundle that brings in a different version of the stringio gem. One way this could happen is when:
* Bundler is *not* invoked directly (e.g. using `bundle exec` or via the Toys bundler integration), *AND*
* In the test code, minitest (which loads stringio) is loaded *before* Rails (which sets up the bundle manually) is initialized.

This is what happened in #245. In Toys 0.15.2 and earlier, the Minitest tool loads minitest first before loading the tests (and initializing Rails), thus triggering the above conditions. We were doing this as a convenience so that tests did not have to load minitest themselves. However, it's probably the case that everyone's Minitest-based tests do explicitly `require "minitest"` or `require "minitest/autorun"` already, so Toys probably doesn't really need to do this. This pull request works around the issue by moving the `require "minitest/autorun"` to the *end* of the script, after all tests are loaded, thus ensuring that Rails loads the bundle-specified stringio gem before Minitest has a chance to load the wrong one.
