### PR TITLE
chore: Relaxed did_you_mean version constraint in test gemfiles

### DIFF
--- a/toys-core/Gemfile
+++ b/toys-core/Gemfile
@@ -8,7 +8,7 @@ gem "abbrev"
 gem "base64"
 # The bundler in Ruby < 3.1 triggers a deprecation warning in did_you_mean 1.6
 # resulting in test failures due to the unexpected output.
-did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : ["~> 1.6"]
+did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : [">= 1.6", "< 3"]
 gem "did_you_mean", *did_you_mean_versions
 gem "highline", "~> 2.0"
 # Minitest 5.16 requires Ruby 2.6 or later. Allow 5.15+ for now.

--- a/toys/Gemfile
+++ b/toys/Gemfile
@@ -9,7 +9,7 @@ gem "abbrev"
 gem "base64"
 # The bundler in Ruby < 3.1 triggers a deprecation warning in did_you_mean 1.6
 # resulting in test failures due to the unexpected output.
-did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : ["~> 1.6"]
+did_you_mean_versions = ::RUBY_VERSION < "3.1" ? ["~> 1.0", "< 1.6"] : [">= 1.6", "< 3"]
 gem "did_you_mean", *did_you_mean_versions
 gem "highline", "~> 2.0"
 # Minitest 5.16 requires Ruby 2.6 or later. Allow 5.15+ for now.


### PR DESCRIPTION
Bundler is having trouble with `did_you_mean` version mismatches.