### PR TITLE
release: Release 2 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v0.16.0 / 2025-10-20
+
+* ADDED: Implement flexible CI system
+* ADDED: Updated minimum Ruby version to 2.7
+
 ### v0.15.6 / 2024-05-15
 
 * FIXED: Fixed argument parsing to allow a flag value with a newline delimited by =

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.15.6"
+    VERSION = "0.16.0"
   end
 
   ##

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v0.16.0 / 2025-10-20
+
+* ADDED: Implement flexible CI system
+* ADDED: Updated minimum Ruby version to 2.7
+
 ### v0.15.6 / 2024-05-15
 
 * FIXED: Fixed argument parsing to allow a flag values delimited by "=" to contain newlines

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.15.6"
+  VERSION = "0.16.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.16.0** (was 0.15.6)
 *  **toys-core 0.16.0** (was 0.15.6)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  ADDED: Implement flexible CI system
 *  ADDED: Updated minimum Ruby version to 2.7

----

## toys-core

 *  ADDED: Implement flexible CI system
 *  ADDED: Updated minimum Ruby version to 2.7
