### PR TITLE
release: Release common-tools 0.16.0 (was 0.15.5.1)

### DIFF
--- a/common-tools/.lib/version.rb
+++ b/common-tools/.lib/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys common tools.
     # @return [String]
     #
-    VERSION = "0.15.5.1"
+    VERSION = "0.16.0"
   end
 end

--- a/common-tools/CHANGELOG.md
+++ b/common-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### v0.16.0 / 2025-10-20
+
+* ADDED: Implement flexible CI system
+* ADDED: New release script implementation
+* ADDED: Release scripts support non-gem releasable units
+* ADDED: Release scripts support more flexible coordination grouping
+
 ### v0.15.5.1 / 2024-02-07
 
 * FIXED: Fixed crash when requesting release of a new gem


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **common-tools 0.16.0** (was 0.15.5.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## common-tools

 *  ADDED: Implement flexible CI system
 *  ADDED: New release script implementation
 *  ADDED: Release scripts support non-gem releasable units
 *  ADDED: Release scripts support more flexible coordination grouping
