### PR TITLE
release: Release common-tools 0.16.1 (was 0.16.0)

### DIFF
--- a/common-tools/.lib/version.rb
+++ b/common-tools/.lib/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys common tools.
     # @return [String]
     #
-    VERSION = "0.16.0"
+    VERSION = "0.16.1"
   end
 end

--- a/common-tools/CHANGELOG.md
+++ b/common-tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.16.1 / 2025-10-31
+
+* FIXED: Release performer no longer reports spurious github check errors
+
 ### v0.16.0 / 2025-10-31
 
 * ADDED: Included flexible CI system


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **common-tools 0.16.1** (was 0.16.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## common-tools

 *  FIXED: Release performer no longer reports spurious github check errors
