### PR TITLE
release: Release common-tools 0.17.0 (was 0.16.2)

### DIFF
--- a/common-tools/.lib/version.rb
+++ b/common-tools/.lib/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys common tools.
     # @return [String]
     #
-    VERSION = "0.16.2"
+    VERSION = "0.17.0"
   end
 end

--- a/common-tools/CHANGELOG.md
+++ b/common-tools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.17.0 / 2025-11-04
+
+* ADDED: Support for include_globs and exclude_globs
+* ADDED: Included the github logs link in release reports
+* ADDED: Remove --enable-releases flag and use TOYS_RELEASE_DRY_RUN environment variable instead
+* ADDED: Add more fine-grained permissions settings to release action workflows
+* ADDED: Support for custom behavior for commit scopes
+* ADDED: Support for modifying commit tag configuration
+* FIXED: Ignore extra text on revert-commit and semver-change tags
+
 ### v0.16.2 / 2025-10-31
 
 * FIXED: Fix crash in the additional change notification


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **common-tools 0.17.0** (was 0.16.2)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## common-tools

 *  ADDED: Support for include_globs and exclude_globs
 *  ADDED: Included the github logs link in release reports
 *  ADDED: Remove --enable-releases flag and use TOYS_RELEASE_DRY_RUN environment variable instead
 *  ADDED: Add more fine-grained permissions settings to release action workflows
 *  ADDED: Support for custom behavior for commit scopes
 *  ADDED: Support for modifying commit tag configuration
 *  FIXED: Ignore extra text on revert-commit and semver-change tags
