### PR TITLE
release: Release common-tools 0.17.1 (was 0.17.0)

### DIFF
--- a/common-tools/.lib/version.rb
+++ b/common-tools/.lib/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys common tools.
     # @return [String]
     #
-    VERSION = "0.17.0"
+    VERSION = "0.17.1"
   end
 end

--- a/common-tools/CHANGELOG.md
+++ b/common-tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.17.1 / 2025-11-04
+
+* FIXED: Toys release request covers all releasable components if no components are specified
+
 ### v0.17.0 / 2025-11-04
 
 * ADDED: Support for include_globs and exclude_globs


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **common-tools 0.17.1** (was 0.17.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## common-tools

 *  FIXED: Toys release request covers all releasable components if no components are specified
