### PR TITLE
release: Release 2 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.17.0 / 2025-11-07
+
+* ADDED: Support loading tools from a gem
+* ADDED: Support for a third argument to flag handlers
+* ADDED: Support for specifying installation options on individual gem installs via the gems mixin
+* ADDED: Support for an environment variable to make git-cache sources writable
+* FIXED: Added standard logger gem to the gemspec to silence Ruby 3.5 warnings
+* DOCS: Updated user guide to cover git and gem loading, and flag handler improvements
+* DOCS: Fixed some internal links in the user's guide
+
 ### v0.16.0 / 2025-10-31
 
 * ADDED: Updated minimum Ruby version to 2.7

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.16.0"
+    VERSION = "0.17.0"
   end
 
   ##

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### v0.17.0 / 2025-11-07
+
+* DOCS: Updated user guide to cover git and gem loading, and flag handler improvements
+* DOCS: Fixed some internal links in the user's guide
+
 ### v0.16.0 / 2025-10-31
 
 * ADDED: Updated minimum Ruby version to 2.7

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.16.0"
+  VERSION = "0.17.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.17.0** (was 0.16.0)
 *  **toys-core 0.17.0** (was 0.16.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  DOCS: Updated user guide to cover git and gem loading, and flag handler improvements
 *  DOCS: Fixed some internal links in the user's guide

----

## toys-core

 *  ADDED: Support loading tools from a gem
 *  ADDED: Support for a third argument to flag handlers
 *  ADDED: Support for specifying installation options on individual gem installs via the gems mixin
 *  ADDED: Support for an environment variable to make git-cache sources writable
 *  FIXED: Added standard logger gem to the gemspec to silence Ruby 3.5 warnings
 *  DOCS: Updated user guide to cover git and gem loading, and flag handler improvements
 *  DOCS: Fixed some internal links in the user's guide
