### PR TITLE
release: Release 4 items

### DIFF
--- a/common-tools/.lib/version.rb
+++ b/common-tools/.lib/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys common tools.
     # @return [String]
     #
-    VERSION = "0.17.1"
+    VERSION = "0.18.0"
   end
 end

--- a/common-tools/CHANGELOG.md
+++ b/common-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### v0.18.0 / 2025-11-29
+
+* BREAKING CHANGE: Removed release tooling from common-tools; use the toys-release gem instead
+* ADDED: Removed release tooling from common-tools; use the toys-release gem instead
+* FIXED: Fixes for initial release
+
 ### v0.17.1 / 2025-11-04
 
 * FIXED: Toys release request covers all releasable components if no components are specified

--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.17.2 / 2025-11-29
+
+* FIXED: Minor formatting fix in the gem install prompt
+
 ### v0.17.1 / 2025-11-07
 
 * FIXED: Rolled back dependency on the logger gem because it is causing some issues with bundler integration

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.17.1"
+    VERSION = "0.17.2"
   end
 
   ##

--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### v0.2.0 / 2025-11-29
+
+* BREAKING CHANGE: Reworked pipeline design and normalized how steps communicate
+* BREAKING CHANGE: Removed defunct commit linter
+* ADDED: Reworked pipeline design and normalized how steps communicate
+* FIXED: Removed defunct commit linter
+
 ### v0.1.1 / 2025-11-09
 
 * FIXED: The gen-gh-pages script now generates the correct redirect paths on a non-monorepo with the default directory structure

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.17.2 / 2025-11-29
+
+* No significant updates.
+
 ### v0.17.1 / 2025-11-07
 
 * FIXED: Rolled back dependency on the logger gem because it is causing some issues with bundler integration

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.17.1"
+  VERSION = "0.17.2"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.17.2** (was 0.17.1)
 *  **toys-core 0.17.2** (was 0.17.1)
 *  **toys-release 0.2.0** (was 0.1.1)
 *  **common-tools 0.18.0** (was 0.17.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  No significant updates.

----

## toys-core

 *  FIXED: Minor formatting fix in the gem install prompt

----

## toys-release

 *  BREAKING CHANGE: Reworked pipeline design and normalized how steps communicate
 *  BREAKING CHANGE: Removed defunct commit linter
 *  ADDED: Reworked pipeline design and normalized how steps communicate
 *  FIXED: Removed defunct commit linter

----

## common-tools

 *  BREAKING CHANGE: Removed release tooling from common-tools; use the toys-release gem instead
 *  ADDED: Removed release tooling from common-tools; use the toys-release gem instead
 *  FIXED: Fixes for initial release
