### PR TITLE
fix(toys-release): Fixed several crashes in the retry tool

### DIFF
--- a/toys-release/toys/.lib/toys/release/pipeline.rb
+++ b/toys-release/toys/.lib/toys/release/pipeline.rb
@@ -468,6 +468,7 @@ module Toys
       def clean_tree(subdir)
         count = 0
         ::Dir.children(subdir || ".").each do |child|
+          next if child == ".git"
           child = ::File.join(subdir, child) if subdir
           if ::File.directory?(child)
             clean_tree(child)

--- a/toys-release/toys/_onclosed.rb
+++ b/toys-release/toys/_onclosed.rb
@@ -88,7 +88,7 @@ def handle_release_merged
     @utils.error("GitHub checks failed", *github_check_errors)
   end
   performer = create_performer
-  performer.perform_pr_releases
+  performer.perform_pr_releases unless performer.error?
   performer.report_results
   if performer.error?
     @utils.error("Releases reported failure")

--- a/toys-release/toys/perform.rb
+++ b/toys-release/toys/perform.rb
@@ -106,11 +106,13 @@ def run
 
   setup_arguments
   setup_performer
-  components.each do |component_spec|
-    name, version = component_spec.split(/[:=]/, 2)
-    confirmation_ui(name, version)
-    gem_version = version ? ::Gem::Version.new(version) : nil
-    @performer.perform_adhoc_release(name, assert_version: gem_version)
+  unless @performer.error?
+    components.each do |component_spec|
+      name, version = component_spec.split(/[:=]/, 2)
+      confirmation_ui(name, version)
+      gem_version = version ? ::Gem::Version.new(version) : nil
+      @performer.perform_adhoc_release(name, assert_version: gem_version)
+    end
   end
   puts @performer.build_report_text
 end


### PR DESCRIPTION
fix(toys-release): Fixed step cleaner trying to clean the .git directory on non-monorepos
fix(toys-release): Repo prechecks can now actually stop releases from being performed
fix(toys-release): Retry tool uses --work-dir= instead of --gh-pages-dir=
fix(toys-release): Dry run mode no longer attempts to update pull requests or open issues