### PR TITLE
release: Release 3 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.18.0 / 2025-12-05
+
+* ADDED: The load_gem directive can now take version requirements as positional arguments
+
 ### v0.17.2 / 2025-11-30
 
 * FIXED: Minor formatting fix in the gem install prompt

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.17.2"
+    VERSION = "0.18.0"
   end
 
   ##

--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+### v0.3.0 / 2025-12-05
+
+* BREAKING CHANGE: Remove component types to simplify configuration mechanism
+* ADDED: Provided a gen-config tool
+* ADDED: Support different options for handling collisions during file copies
+* ADDED: Support for per-component overrides of commit tag behavior
+* ADDED: Remove component types to simplify configuration mechanism
+* ADDED: Check for unknown or misspelled keys when loading configuration
+* ADDED: The gen-config tool now generates git_user_name and git_user_email fields
+* DOCS: Initial work on the users guide
+
 ### v0.2.2 / 2025-11-30
 
 * FIXED: Fixed several crashes in the retry tool

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.18.0 / 2025-12-05
+
+* No significant updates.
+
 ### v0.17.2 / 2025-11-30
 
 * DOCS: Fixed minor typos in readme files

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.17.2"
+  VERSION = "0.18.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.18.0** (was 0.17.2)
 *  **toys-core 0.18.0** (was 0.17.2)
 *  **toys-release 0.3.0** (was 0.2.2)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  No significant updates.

----

## toys-core

 *  ADDED: The load_gem directive can now take version requirements as positional arguments

----

## toys-release

 *  BREAKING CHANGE: Remove component types to simplify configuration mechanism
 *  ADDED: Provided a gen-config tool
 *  ADDED: Support different options for handling collisions during file copies
 *  ADDED: Support for per-component overrides of commit tag behavior
 *  ADDED: Remove component types to simplify configuration mechanism
 *  ADDED: Check for unknown or misspelled keys when loading configuration
 *  ADDED: The gen-config tool now generates git_user_name and git_user_email fields
 *  DOCS: Initial work on the users guide
