### PR TITLE
fix: Support for the logger gem in Ruby 4.0

### DIFF
--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "logger"
+
 module Toys
   ##
   # A Toys-based CLI.
@@ -562,7 +564,6 @@ module Toys
       # @return [Proc]
       #
       def default_logger_factory
-        require "logger"
         proc do
           logger = ::Logger.new($stderr)
           logger.level = ::Logger::WARN

--- a/toys-core/lib/toys/utils/exec.rb
+++ b/toys-core/lib/toys/utils/exec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "logger"
+
 module Toys
   module Utils
     ##
@@ -263,7 +265,6 @@ module Toys
       #
       def initialize(**opts, &block)
         require "rbconfig"
-        require "logger"
         require "stringio"
         @default_opts = Opts.new(&block).add(opts)
       end

--- a/toys-core/lib/toys/utils/standard_ui.rb
+++ b/toys-core/lib/toys/utils/standard_ui.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "logger"
+
 module Toys
   module Utils
     ##
@@ -28,7 +30,6 @@ module Toys
       #     terminal output. Default is `$stderr`.
       #
       def initialize(output: nil)
-        require "logger"
         require "toys/utils/terminal"
         @terminal = output || $stderr
         @terminal = Terminal.new(output: @terminal) unless @terminal.is_a?(Terminal)

--- a/toys-core/test-data/gems-cases/bundle-with-compatible-toys/Gemfile
+++ b/toys-core/test-data/gems-cases/bundle-with-compatible-toys/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "abbrev"
 gem "highline", "~> 2.0"
-gem "toys", ">= 0.10.0"
+gem "toys", ">= 0.16.0"

--- a/toys-core/toys-core.gemspec
+++ b/toys-core/toys-core.gemspec
@@ -22,6 +22,8 @@ require "toys/core"
   spec.required_ruby_version = ">= 2.7.0"
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "logger"
+
   if spec.respond_to?(:metadata)
     spec.metadata["changelog_uri"] = "https://dazuma.github.io/toys/gems/toys-core/v#{::Toys::Core::VERSION}/file.CHANGELOG.html"
     spec.metadata["source_code_uri"] = "https://github.com/dazuma/toys/tree/main/toys-core"


### PR DESCRIPTION
Adds logger to the set of explicit dependencies of toys-core, for compatibility with Ruby 4.0. Also ensure that logger is actually loaded whenever toys-core is loaded, so that bundler integration will notice that it is a dependency and handle it appropriately.

Fixes #368 
