### PR TITLE
release: Release toys-release 0.3.2 (was 0.3.1)

### DIFF
--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.3.2 / 2025-12-25
+
+* DOCS: Some formatting fixes in the user guide
+
 ### v0.3.1 / 2025-12-22
 
 * FIXED: Reset the local repository prior to each pipeline step

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys-release 0.3.2** (was 0.3.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-release

 *  DOCS: Some formatting fixes in the user guide
