### PR TITLE
release: Release toys-release 0.5.0 (was 0.4.0)

### DIFF
--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### v0.5.0 / 2026-01-22
+
+* ADDED: Support for updating release pull requests when new commits are added
+* FIXED: Use v6 of the checkout action
+* FIXED: Reverting a commit that itself does a revert does the right thing
+
 ### v0.4.0 / 2026-01-06
 
 * ADDED: Actions workflows use Ruby 4.0 and Toys 0.19 or later

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys-release 0.5.0** (was 0.4.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-release

 *  ADDED: Support for updating release pull requests when new commits are added
 *  FIXED: Use v6 of the checkout action
 *  FIXED: Reverting a commit that itself does a revert does the right thing

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "request_input_string": "toys toys-core toys-release common-tools"
}
```
