### PR TITLE
release: Release 2 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+### v0.20.0 / 2026-01-24
+
+* ADDED: Support for updating release pull requests when new commits are added
+* ADDED: Multiple release pull requests are now allowed as long as they don't release any of the same components
+* FIXED: Reverting a commit that itself does a revert does the right thing
+* FIXED: Fixed error when requesting a release from a branch with a slash in the name
+* FIXED: Another significant update test
+* FIXED: Formatting updates
+
 ### v0.19.1 / 2026-01-06
 
 * DOCS: Some formatting fixes in the user guide

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.19.1"
+    VERSION = "0.20.0"
   end
 
   ##

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.20.0 / 2026-01-24
+
+* No significant updates.
+
 ### v0.19.1 / 2026-01-06
 
 * FIXED: The minitest template and the "system test" builtin now support minitest 6

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.19.1"
+  VERSION = "0.20.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.20.0** (was 0.19.1)
 *  **toys-core 0.20.0** (was 0.19.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  No significant updates.

----

## toys-core

 *  ADDED: Support for updating release pull requests when new commits are added
 *  ADDED: Multiple release pull requests are now allowed as long as they don't release any of the same components
 *  FIXED: Reverting a commit that itself does a revert does the right thing
 *  FIXED: Fixed error when requesting a release from a branch with a slash in the name
 *  FIXED: Another significant update test
 *  FIXED: Formatting updates

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "request_arguments": [
    "toys"
  ]
}
```
