### PR TITLE
release: Release 3 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.19.2 / 2026-01-27
+
+* FIXED: Update toys-core 3
+
 ### v0.19.1 / 2026-01-06
 
 * DOCS: Some formatting fixes in the user guide

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.19.1"
+    VERSION = "0.19.2"
   end
 
   ##

--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.5.0 / 2026-01-27
+
+* ADDED: Support for updating release pull requests when new commits are added
+* ADDED: Multiple release pull requests are now allowed as long as they don't release any of the same components
+* FIXED: Use v6 of the checkout action
+* FIXED: Reverting a commit that itself does a revert does the right thing
+* FIXED: Fixed error when requesting a release from a branch with a slash in the name
+* FIXED: Update toys-release
+* FIXED: Update toys-release 4
+
 ### v0.4.0 / 2026-01-06
 
 * ADDED: Actions workflows use Ruby 4.0 and Toys 0.19 or later

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.19.2 / 2026-01-27
+
+* No significant updates.
+
 ### v0.19.1 / 2026-01-06
 
 * FIXED: The minitest template and the "system test" builtin now support minitest 6

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.19.1"
+  VERSION = "0.19.2"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.19.2** (was 0.19.1)
 *  **toys-core 0.19.2** (was 0.19.1)
 *  **toys-release 0.5.0** (was 0.4.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  No significant updates.

----

## toys-core

 *  FIXED: Update toys-core 3

----

## toys-release

 *  ADDED: Support for updating release pull requests when new commits are added
 *  ADDED: Multiple release pull requests are now allowed as long as they don't release any of the same components
 *  FIXED: Use v6 of the checkout action
 *  FIXED: Reverting a commit that itself does a revert does the right thing
 *  FIXED: Fixed error when requesting a release from a branch with a slash in the name
 *  FIXED: Update toys-release
 *  FIXED: Update toys-release 4

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys": null,
    "toys-core": null,
    "toys-release": null
  },
  "request_sha": "3a9f36436478a64f7322b14409657a0215af275c"
}
```
