### PR TITLE
fix(release): Fixed additional cases of releases attempting to release components whose names are substrings of other components

### DIFF
--- a/toys-release/docs/guide.md
+++ b/toys-release/docs/guide.md
@@ -514,6 +514,24 @@ and affect the behavior of that and other commits.
     can even include multiple revert-commit tags if the commit reverts more than
     one previous commit.
 
+ *  **touch-component:** This tag indicates that the commit should be treated
+    as if it touches a specified component, even if it does not actually modify
+    that component's files. For example:
+
+    ```
+    fix: Fix the build
+    touch-component: my_gem
+    ```
+
+ *  **no-touch-component:** This tag indicates that the commit should be
+    treated as if it does *not* touch a specified component, even if it
+    modifies that component's files. For example:
+
+    ```
+    fix: Fix the build
+    no-touch-component: my_gem
+    ```
+
 ### Running on the command line
 
 The implementation of Toys-Release is done via Toys (i.e. command line) tools.

--- a/toys-release/toys/.lib/toys/release/component.rb
+++ b/toys-release/toys/.lib/toys/release/component.rb
@@ -293,7 +293,9 @@ module Toys
         dir = settings.directory
         dir = "#{dir}/" unless dir.end_with?("/")
 
-        return true if dir == "./" || /(^|\n)touch-component: #{name}(\s|$)/i.match?(commit.message)
+        escaped_name = ::Regexp.escape(name)
+        return true if dir == "./" || /(^|\n)touch-component:\s+#{escaped_name}(\s|$)/i.match?(commit.message)
+        return false if /(^|\n)no-touch-component:\s+#{escaped_name}(\s|$)/i.match?(commit.message)
         commit.modified_paths.any? do |file|
           (file.start_with?(dir) || settings.include_globs.any? { |pattern| ::File.fnmatch?(pattern, file) }) &&
             settings.exclude_globs.none? { |pattern| ::File.fnmatch?(pattern, file) }

--- a/toys-release/toys/.lib/toys/release/repository.rb
+++ b/toys-release/toys/.lib/toys/release/repository.rb
@@ -680,6 +680,7 @@ module Toys
         files = output.split("\n")
         components = all_components.find_all do |component|
           dir = component.directory
+          dir = "#{dir}/" unless dir.end_with?("/")
           files.any? { |file| file.start_with?(dir) }
         end
         components.each_with_object({}) do |component, result|

--- a/toys-release/toys/.test/test_repository.rb
+++ b/toys-release/toys/.test/test_repository.rb
@@ -112,6 +112,16 @@ describe Toys::Release::Repository do
     assert_equal(::Gem::Version.new("0.15.5"), data["toys"])
   end
 
+  it "determines multiple released component and version from pull request checking for substring bug" do
+    pull_request = Toys::Release::Tests::FakePullRequest.new(
+      merge_commit_sha: "9943eda4cf85a235940a68e38aae3149e6dd994b",
+      head_ref: "release/multi/20251030192335-123456/main"
+    )
+    data = repository.released_components_and_versions(pull_request)
+    assert_equal(1, data.size)
+    assert_equal(::Gem::Version.new("0.5.0"), data["toys-release"])
+  end
+
   it "gets a commit info" do
     commit = repository.commit_info("toys/v0.19.0")
     assert_includes(commit.message, "release: Release 3 items (#375)")


### PR DESCRIPTION
fix(release): Fixed several issues with the retry tool
docs(release): Document the touch-component and no-touch-component tags