### PR TITLE
release: Release toys-release 0.5.1 (was 0.5.0)

### DIFF
--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### v0.5.1 / 2026-01-27
+
+* FIXED: Fixed additional cases of releases attempting to release components whose names are substrings of other components
+* FIXED: Fixed several issues with the retry tool
+* DOCS: Document the touch-component and no-touch-component tags
+
 ### v0.5.0 / 2026-01-27
 
 * BREAKING CHANGE: Disabled GitHub check validation by default, because GitHub started adding hidden checks we can't account for

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys-release 0.5.1** (was 0.5.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-release

 *  FIXED: Fixed additional cases of releases attempting to release components whose names are substrings of other components
 *  FIXED: Fixed several issues with the retry tool
 *  DOCS: Document the touch-component and no-touch-component tags

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys": null,
    "toys-core": null,
    "toys-release": null,
    "common-tools": null
  },
  "request_sha": "f2f7a4385f1abc298f8b966bae8ef2c36878a3d8"
}
```
