### PR TITLE
Restore truffleruby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,9 @@ jobs:
           - os: ubuntu-latest
             ruby: "jruby"
             steps: "--test-all --no-test-tools --no-test-release"
-          # TEMPORARY: Disable truffleruby due to some issues with bundler
-          # - os: ubuntu-latest
-          #   ruby: "truffleruby"
-          #   steps: "--test-all --no-test-tools --no-test-release"
+          - os: ubuntu-latest
+            ruby: "truffleruby"
+            steps: "--test-all --no-test-tools --no-test-release"
           - os: macos-latest
             ruby: "2.7"
             steps: "--test-all --no-test-tools --no-test-release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,10 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
   tests:
-    if: ${{ github.repository == 'dazuma/toys' }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
From https://github.com/dazuma/toys/pull/264
The comment mention an issue with Bundler, which is most likely https://github.com/truffleruby/truffleruby/issues/3869 which has been fixed in TruffleRuby 33.