### PR TITLE
fix(release): Strip changelog entries of trailing whitespace

### DIFF
--- a/toys-release/toys/.lib/toys/release/change_set.rb
+++ b/toys-release/toys/.lib/toys/release/change_set.rb
@@ -218,11 +218,12 @@ module Toys
 
       def create_description_normalizer(issue_number_suffix_handling, repo_path)
         proc do |description|
+          description = description.strip
           match = /^([a-z])(.*)$/.match(description)
           description = match[1].upcase + match[2] if match
           unless issue_number_suffix_handling == :plain
             suffixes = []
-            while (match = /^(.*\S)(\s*\(#\d+\)\s*)$/.match(description))
+            while (match = /^(.*\S)(\s*\(#\d+\))$/.match(description))
               suffixes << match[2]
               description = match[1]
             end

--- a/toys-release/toys/.test/test_change_set.rb
+++ b/toys-release/toys/.test/test_change_set.rb
@@ -89,7 +89,7 @@ describe Toys::Release::ChangeSet do
     assert_equal(Toys::Release::Semver::MINOR, change_set.semver)
     groups = change_set.change_groups
     assert_equal(1, groups.size)
-    assert_equal(["ADDED: Feature 1 (#123) (#456) "], groups[0].prefixed_changes)
+    assert_equal(["ADDED: Feature 1 (#123) (#456)"], groups[0].prefixed_changes)
     refute_empty(change_set)
   end
 
@@ -112,7 +112,7 @@ describe Toys::Release::ChangeSet do
     groups = change_set.change_groups
     assert_equal(1, groups.size)
     expected_entry = "ADDED: Feature 1 ([#123](https://github.com/example/repo/pull/123)) " \
-                     "([#456](https://github.com/example/repo/pull/456)) "
+                     "([#456](https://github.com/example/repo/pull/456))"
     assert_equal([expected_entry], groups[0].prefixed_changes)
     refute_empty(change_set)
   end


### PR DESCRIPTION
Fixes #418