### PR TITLE
feat(release): Add configurable changelog_bullet setting

### DIFF
--- a/toys-release/toys/.lib/toys/release/changelog_file.rb
+++ b/toys-release/toys/.lib/toys/release/changelog_file.rb
@@ -100,8 +100,9 @@ module Toys
       # @param changeset [ChangeSet] The changeset.
       # @param version [String] The release version.
       # @param date [String] The date. If not provided, uses the current UTC.
+      # @param bullet [String] The bullet character for list items. Defaults to "*".
       #
-      def append(changeset, version, date: nil)
+      def append(changeset, version, date: nil, bullet: "*")
         @utils.log("Writing version #{version} to changelog #{path}")
         date ||= ::Time.now.utc
         date = date.strftime("%Y-%m-%d") if date.respond_to?(:strftime)
@@ -110,7 +111,7 @@ module Toys
           "",
         ]
         changeset.change_groups.each do |group|
-          new_entry.concat(group.prefixed_changes.map { |line| "* #{line}" })
+          new_entry.concat(group.prefixed_changes.map { |line| "#{bullet} #{line}" })
         end
         new_entry = new_entry.join("\n")
         old_content = content || DEFAULT_HEADER

--- a/toys-release/toys/.lib/toys/release/repo_settings.rb
+++ b/toys-release/toys/.lib/toys/release/repo_settings.rb
@@ -694,6 +694,11 @@ module Toys
       attr_reader :no_significant_updates_notice
 
       ##
+      # @return [String] The bullet character used in changelog entries
+      #
+      attr_reader :changelog_bullet
+
+      ##
       # @return [String] GitHub label applied for pending release
       #
       attr_reader :release_pending_label
@@ -962,6 +967,9 @@ module Toys
       DEFAULT_RELEASE_COMPLETE_LABEL = "release: complete"
       private_constant :DEFAULT_RELEASE_COMPLETE_LABEL
 
+      DEFAULT_CHANGELOG_BULLET = "*"
+      private_constant :DEFAULT_CHANGELOG_BULLET
+
       def read_global_info(info)
         @main_branch = info.delete("main_branch") || DEFAULT_MAIN_BRAMCH
         @repo_path = info.delete("repo")
@@ -1001,6 +1009,11 @@ module Toys
         @no_significant_updates_notice =
           info.delete("no_significant_updates_notice") || DEFAULT_NO_SIGNIFICANT_UPDATES_NOTICE
         @issue_number_suffix_handling = read_issue_number_suffix_handling(info, DEFAULT_ISSUE_NUMBER_SUFFIX_HANDLING)
+        @changelog_bullet = info.delete("changelog_bullet") || DEFAULT_CHANGELOG_BULLET
+        unless ["*", "-"].include?(@changelog_bullet)
+          @errors << "Unrecognized changelog_bullet setting: #{@changelog_bullet.inspect}. Expected \"*\" or \"-\"."
+          @changelog_bullet = DEFAULT_CHANGELOG_BULLET
+        end
       end
 
       def read_default_step_info(info)

--- a/toys-release/toys/.lib/toys/release/request_logic.rb
+++ b/toys-release/toys/.lib/toys/release/request_logic.rb
@@ -119,7 +119,8 @@ module Toys
       def change_files
         @request_spec.resolved_components.each do |resolved_component|
           component = @repository.component_named(resolved_component.component_name)
-          component.changelog_file.append(resolved_component.change_set, resolved_component.version)
+          component.changelog_file.append(resolved_component.change_set, resolved_component.version,
+                                          bullet: @settings.changelog_bullet)
           component.version_rb_file.update_version(resolved_component.version)
         end
       end

--- a/toys-release/toys/.test/test_changelog_file.rb
+++ b/toys-release/toys/.test/test_changelog_file.rb
@@ -86,6 +86,22 @@ describe Toys::Release::ChangelogFile do
     end
   end
 
+  it "appends to a file with dash bullets" do
+    Dir.mktmpdir do |dir|
+      changelog_path = File.join(dir, "changelog.md")
+      FileUtils.cp(changelog3_path, changelog_path)
+      file = Toys::Release::ChangelogFile.new(changelog_path, environment_utils)
+      change_set.add_commit(
+        commit_with("abcde1", "fix: fix for uri version mismatch error")
+      )
+      change_set.finish
+      file.append(change_set, "0.15.5", date: "2024-01-31", bullet: "-")
+      result = file.content
+      assert_includes(result, "- FIXED:")
+      refute_includes(result, "* FIXED:")
+    end
+  end
+
   it "appends to an empty file" do
     Dir.mktmpdir do |dir|
       changelog_path = File.join(dir, "changelog.md")

--- a/toys-release/toys/.test/test_repo_settings.rb
+++ b/toys-release/toys/.test/test_repo_settings.rb
@@ -24,6 +24,7 @@ describe Toys::Release::RepoSettings do
     assert_equal(:delete, settings.issue_number_suffix_handling)
     assert_equal("BREAKING CHANGE", settings.breaking_change_header)
     assert_equal("No significant updates.", settings.no_significant_updates_notice)
+    assert_equal("*", settings.changelog_bullet)
 
     assert_equal(["toys", "toys-core", "toys-release", "common-tools"], settings.all_component_names)
     assert_equal(["toys", "toys-core", "toys-release", "common-tools"], settings.all_component_settings.map(&:name))
@@ -374,5 +375,23 @@ describe Toys::Release::RepoSettings do
       bar_component = settings.component_settings("bar")
       assert_includes(bar_component.steps.map(&:name), "build_gem")
     end
+  end
+
+  it "accepts a dash changelog_bullet" do
+    input = YAML.load(<<~STRING)
+      changelog_bullet: "-"
+    STRING
+    settings = Toys::Release::RepoSettings.new(input)
+    assert_equal("-", settings.changelog_bullet)
+    refute(settings.errors.any? { |err| err.include?("changelog_bullet") })
+  end
+
+  it "rejects an invalid changelog_bullet" do
+    input = YAML.load(<<~STRING)
+      changelog_bullet: "+"
+    STRING
+    settings = Toys::Release::RepoSettings.new(input)
+    assert_equal("*", settings.changelog_bullet)
+    assert(settings.errors.any? { |err| err.include?("changelog_bullet") })
   end
 end


### PR DESCRIPTION
## Summary

- Add optional `changelog_bullet` config field to `releases.yml` that controls which bullet character (`*` or `-`) is used in generated changelog entries, defaulting to `*`
- Thread the setting through `RepoSettings` -> `RequestLogic` -> `ChangelogFile#append`
- Validate the value and report an error for unrecognized bullets

## Test plan

- [x] Existing tests pass (238 runs, 711 assertions)
- [x] New test: default `changelog_bullet` is `"*"` in toys repo settings
- [x] New test: `changelog_bullet: "-"` is accepted without errors
- [x] New test: `changelog_bullet: "+"` is rejected with an error, falls back to `"*"`
- [x] New test: `ChangelogFile#append` with `bullet: "-"` produces dash-prefixed lines
- [x] RuboCop passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)