### PR TITLE
release: Release toys-release 0.6.0 (was 0.5.1)

### DIFF
--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.6.0 / 2026-02-11
+
+* ADDED: Support retaining and/or linkifying issue/PR numbers in commit messages
+* ADDED: Support for configuring the bullet used for changelog items
+* FIXED: Deprecated the version_constant configuration
+* FIXED: Strip changelog entries of trailing whitespace
+* FIXED: Fixed a crash in the requester when the version constant cannot be found
+* FIXED: Version constant can now be set using single quotes
+* FIXED: Added base64 gem to the dependencies and updated toys-core dependency
+
 ### v0.5.1 / 2026-01-27
 
 * FIXED: Fixed additional cases of releases attempting to release components whose names are substrings of other components

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.5.1"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys-release 0.6.0** (was 0.5.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-release

 *  ADDED: Support retaining and/or linkifying issue/PR numbers in commit messages
 *  ADDED: Support for configuring the bullet used for changelog items
 *  FIXED: Deprecated the version_constant configuration
 *  FIXED: Strip changelog entries of trailing whitespace
 *  FIXED: Fixed a crash in the requester when the version constant cannot be found
 *  FIXED: Version constant can now be set using single quotes
 *  FIXED: Added base64 gem to the dependencies and updated toys-core dependency

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys-release": null
  },
  "request_sha": "49b92833d31e26a843016207984f22da260bc9f0"
}
```
