### PR TITLE
feat(toys): Support for gem management without bundler in the minitest tool template

### DIFF
--- a/toys/.toys/.toys.rb
+++ b/toys/.toys/.toys.rb
@@ -9,7 +9,7 @@ end
 
 expand :clean, paths: :gitignore
 
-expand :minitest, libs: ["lib", "test"], bundler: true, mt_compat: true
+expand :minitest, libs: ["lib", "test"], bundler: true
 
 tool "test" do
   flag :integration_tests, "--integration-tests", "--integration", desc: "Enable integration tests"

--- a/toys/lib/toys/templates/minitest.rb
+++ b/toys/lib/toys/templates/minitest.rb
@@ -9,10 +9,15 @@ module Toys
       include Template
 
       ##
-      # Default version requirements for the minitest gem.
-      # @return [Array<String>]
+      # Default version requirements for gem names.
+      # @return [Hash{String=>Array<String>}]
       #
-      DEFAULT_GEM_VERSION_REQUIREMENTS = [">= 5.0", "< 7"].freeze
+      DEFAULT_GEM_VERSION_REQUIREMENTS = {
+        "minitest" => [">= 5.0", "< 7"].freeze,
+        "minitest-mock" => ["~> 5.27"].freeze,
+        "minitest-focus" => ["~> 1.4", ">= 1.4.1"].freeze,
+        "minitest-rg" => ["~> 5.4"].freeze,
+      }.freeze
 
       ##
       # Default tool name
@@ -37,10 +42,28 @@ module Toys
       #
       # @param name [String] Name of the tool to create. Defaults to
       #     {DEFAULT_TOOL_NAME}.
-      # @param gem_version [String,Array<String>] Version requirements for
-      #     the minitest gem. Optional. If not provided, uses the bundled
-      #     version if bundler is enabled, or defaults to
-      #     {DEFAULT_GEM_VERSION_REQUIREMENTS} if bundler is not enabled.
+      # @param minitest [String,Array<String>] Version requirements for
+      #     the "minitest" gem. Optional. If not provided, defaults to the
+      #     value given in {DEFAULT_GEM_VERSION_REQUIREMENTS}.
+      #     Ignored if bundler is enabled.
+      # @param gem_version [String,Array<String>] Deprecated alias for the
+      #     `minitest` argument.
+      # @param minitest_mock [String,Array<String>,true] Include the
+      #     "minitest-mock" gem with the given version requirements. If true
+      #     is passed, the value in {DEFAULT_GEM_VERSION_REQUIREMENTS} is used.
+      #     Ignored if bundler is enabled.
+      # @param minitest_focus [String,Array<String>,true] Include the
+      #     "minitest-focus" gem with the given version requirements. If true
+      #     is passed, the value in {DEFAULT_GEM_VERSION_REQUIREMENTS} is used.
+      #     Ignored if bundler is enabled.
+      # @param minitest_rg [String,Array<String>,true] Include the
+      #     "minitest-rg" gem with the given version requirements. If true
+      #     is passed, the value in {DEFAULT_GEM_VERSION_REQUIREMENTS} is used.
+      #     Ignored if bundler is enabled.
+      # @param gems [Hash{String=>String|Array<String>|true}] Include the given
+      #     gems with the given version requirements. If true is provided for
+      #     a version, then no version requirements are imposed.
+      #     Ignored if bundler is enabled.
       # @param libs [Array<String>] An array of library paths to add to the
       #     ruby require path. Defaults to {DEFAULT_LIBS}.
       # @param files [Array<String>] An array of globs indicating the test
@@ -63,6 +86,11 @@ module Toys
       #     when executing this tool.
       #
       def initialize(name: nil,
+                     minitest: nil,
+                     minitest_mock: nil,
+                     minitest_focus: nil,
+                     minitest_rg: nil,
+                     gems: nil,
                      gem_version: nil,
                      libs: nil,
                      files: nil,
@@ -73,7 +101,6 @@ module Toys
                      mt_compat: nil,
                      context_directory: nil)
         @name = name
-        @gem_version = gem_version
         @libs = libs
         @files = files
         @seed = seed
@@ -82,6 +109,14 @@ module Toys
         @bundler = bundler
         @mt_compat = mt_compat
         @context_directory = context_directory
+        @gem_dependencies = {}
+        unless @bundler
+          update_version_spec("minitest", minitest || gem_version || true)
+          update_version_spec("minitest-mock", minitest_mock)
+          update_version_spec("minitest-focus", minitest_focus)
+          update_version_spec("minitest-rg", minitest_rg)
+          update_gems(gems) if gems
+        end
       end
 
       ##
@@ -93,15 +128,73 @@ module Toys
       attr_writer :name
 
       ##
+      # Update gems and version requirements.
+      # Ignored if bundler is enabled.
+      #
+      # @param gems [Hash{String=>String|Array<String>|true|false|nil}]
+      #     A mapping from gem name to either the version requirements,
+      #     `true` to indicate no particular version restrictions, or `false`
+      #     or `nil` to remove the gem from the list. (Note that it is not
+      #     possible to remove the `minitest` gem, and setting it to `nil`
+      #     will simply restore the default version restrictions.)
+      # @return [self]
+      #
+      def update_gems(gems)
+        unless @bundler
+          gems.each do |gem_name, version_requirements|
+            update_version_spec(gem_name, version_requirements)
+          end
+        end
+        self
+      end
+
+      ##
       # Version requirements for the minitest gem.
-      # If set to `nil`, uses the bundled version if bundler is enabled, or
-      # defaults to {DEFAULT_GEM_VERSION_REQUIREMENTS} if bundler is not
-      # enabled.
+      # If set to `true` or `nil`, a default version requirement is used.
+      # Ignored if bundler is enabled.
       #
-      # @param value [String,Array<String>,nil]
-      # @return [String,Array<String>,nil]
+      # @param value [String,Array<String>,true,nil]
       #
-      attr_writer :gem_version
+      def minitest=(value)
+        update_version_spec("minitest", value || true) unless @bundler
+      end
+      alias gem_version= minitest=
+
+      ##
+      # Version requirements for the minitest-mock gem.
+      # If set to `true`, a default version requirement is used.
+      # If set to `nil`, minitest-mock is removed from the gem dependencies.
+      # Ignored if bundler is enabled.
+      #
+      # @param value [String,Array<String>,true,nil]
+      #
+      def minitest_mock=(value)
+        update_version_spec("minitest-mock", value) unless @bundler
+      end
+
+      ##
+      # Version requirements for the minitest-focus gem.
+      # If set to `true`, a default version requirement is used.
+      # If set to `nil`, minitest-focus is removed from the gem dependencies.
+      # Ignored if bundler is enabled.
+      #
+      # @param value [String,Array<String>,true,nil]
+      #
+      def minitest_focus=(value)
+        update_version_spec("minitest-focus", value) unless @bundler
+      end
+
+      ##
+      # Version requirements for the minitest-rg gem.
+      # If set to `true`, a default version requirement is used.
+      # If set to `nil`, minitest-rg is removed from the gem dependencies.
+      # Ignored if bundler is enabled.
+      #
+      # @param value [String,Array<String>,true,nil]
+      #
+      def minitest_rg=(value)
+        update_version_spec("minitest-rg", value) unless @bundler
+      end
 
       ##
       # An array of library paths to add to the ruby require path.
@@ -221,6 +314,13 @@ module Toys
       ##
       # @private
       #
+      def gem_dependencies
+        @bundler ? nil : @gem_dependencies
+      end
+
+      ##
+      # @private
+      #
       def name
         @name || DEFAULT_TOOL_NAME
       end
@@ -237,14 +337,6 @@ module Toys
       #
       def files
         @files ? Array(@files) : DEFAULT_FILES
-      end
-
-      ##
-      # @private
-      #
-      def gem_version
-        return Array(@gem_version) if @gem_version
-        @bundler ? [] : DEFAULT_GEM_VERSION_REQUIREMENTS
       end
 
       ##
@@ -284,48 +376,108 @@ module Toys
                          complete: :file_system,
                          desc: "Paths to the tests to run (defaults to all tests)"
 
-          static :gem_version, template.gem_version
+          static :gem_dependencies, template.gem_dependencies
           static :libs, template.libs
           static :files, template.files
           static :template_verbose, template.verbose
           static :mt_compat, template.mt_compat
 
           # @private
-          def run # rubocop:disable all
-            gem "minitest", *gem_version
-
+          def run
+            loaded_gem_versions = load_gems
             ::Dir.chdir(context_directory || ::Dir.getwd) do
-              ruby_args = []
-              ruby_args << "-I#{libs.join(::File::PATH_SEPARATOR)}" unless libs.empty?
-              ruby_args << "-w" if warnings
-
-              if tests.empty?
-                files.each do |pattern|
-                  tests.concat(::Dir.glob(pattern))
-                end
-                tests.uniq!
-              end
-              code = tests.map { |file| "load '#{file}'" } + ["require 'minitest/autorun'"]
-              ruby_args << "-e" << code.join("\n")
-
-              ruby_args << "--"
-              ruby_args << "--seed" << seed if seed
-              vv = verbosity
-              vv += 1 if template_verbose
-              ruby_args << "--verbose" if vv.positive?
-              ruby_args << "--name" << name if name
-              ruby_args << "--exclude" << exclude if exclude
-
-              env = {}
-              env["MT_COMPAT"] = mt_compat ? "true" : nil unless mt_compat.nil?
-
-              result = exec_ruby(ruby_args, env: env)
+              result = exec_ruby(ruby_args(loaded_gem_versions), env: ruby_env)
               if result.error?
                 logger.error("Minitest failed!")
                 exit(result.exit_code)
               end
             end
           end
+
+          # @private
+          def load_gems
+            return nil unless gem_dependencies
+            gem_dependencies.each do |gem_name, version_requirements|
+              next if gem_name == "minitest"
+              gem gem_name, *version_requirements
+            end
+            gem "minitest", *gem_dependencies["minitest"]
+            loaded_versions = {}
+            Gem.loaded_specs.each_value do |spec|
+              loaded_versions[spec.name] = spec.version.to_s if gem_dependencies.key?(spec.name)
+            end
+            loaded_versions
+          end
+
+          # @private
+          def ruby_env
+            case mt_compat
+            when true
+              { "MT_COMPAT" => "true" }
+            when false
+              { "MT_COMPAT" => nil }
+            else
+              {}
+            end
+          end
+
+          # @private
+          def ruby_code_lines(loaded_gem_versions)
+            code = []
+            if loaded_gem_versions
+              loaded_gem_versions.each do |gem_name, gem_version|
+                code << "gem #{gem_name.inspect}, #{gem_version.inspect}"
+              end
+            else
+              code << "require 'bundler/setup'"
+            end
+            loaded_gems = Gem.loaded_specs
+            ["minitest", "minitest-mock", "minitest-focus", "minitest-rg"].each do |gem_name|
+              code << "require #{gem_name.tr('-', '/').inspect}" if loaded_gems.key?(gem_name)
+            end
+            if tests.empty?
+              files.each do |pattern|
+                tests.concat(::Dir.glob(pattern))
+              end
+              tests.uniq!
+            end
+            code << "require 'minitest/autorun'"
+            code.concat(tests.map { |path| "load #{path.inspect}" })
+            code
+          end
+
+          # @private
+          def ruby_args(loaded_gem_versions)
+            args = []
+            args << "-I#{libs.join(::File::PATH_SEPARATOR)}" unless libs.empty?
+            args << "-w" if warnings
+            args << "-e" << ruby_code_lines(loaded_gem_versions).join("\n")
+            args << "--"
+            args << "--seed" << seed if seed
+            vv = verbosity
+            vv += 1 if template_verbose
+            args << "--verbose" if vv.positive?
+            args << "--name" << name if name
+            args << "--exclude" << exclude if exclude
+            args
+          end
+        end
+      end
+
+      private
+
+      def update_version_spec(gem_name, version_requirements)
+        version_requirements ||= true if gem_name == "minitest"
+        if version_requirements
+          @gem_dependencies[gem_name] =
+            if version_requirements == true
+              DEFAULT_GEM_VERSION_REQUIREMENTS[gem_name] || []
+            else
+              Array(version_requirements).map(&:to_s)
+            end
+        else
+          @gem_dependencies.delete(gem_name)
+          nil
         end
       end
     end

--- a/toys/test-data/minitest-cases/focus/.toys.rb
+++ b/toys/test-data/minitest-cases/focus/.toys.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+truncate_load_path!
+
+expand :minitest, name: "test-without", files: "foo.rb"
+
+expand :minitest, name: "test-direct", files: "foo.rb", minitest_focus: true
+
+expand :minitest, name: "test-bundle", files: "foo.rb", bundler: true

--- a/toys/test-data/minitest-cases/focus/Gemfile
+++ b/toys/test-data/minitest-cases/focus/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gem "minitest", ">= 5.26", "< 7"
+gem "minitest-focus", "~> 1.4"

--- a/toys/test-data/minitest-cases/focus/foo.rb
+++ b/toys/test-data/minitest-cases/focus/foo.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe "foo" do
+  focus
+  it "passes" do
+    assert(true)
+  end
+
+  it "fails" do
+    assert(false)
+  end
+end

--- a/toys/test-data/minitest-cases/multiple/bar.rb
+++ b/toys/test-data/minitest-cases/multiple/bar.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "bar" do
+  it "passes" do
+    assert(true)
+  end
+end

--- a/toys/test-data/minitest-cases/multiple/foo.rb
+++ b/toys/test-data/minitest-cases/multiple/foo.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "foo" do
+  it "fails" do
+    assert(false)
+  end
+end

--- a/toys/test/test_minitest.rb
+++ b/toys/test/test_minitest.rb
@@ -38,14 +38,74 @@ describe "minitest template" do
       assert_equal(["test/**/test*.rb"], template.files)
     end
 
-    it "handles the gem_version field without bundler" do
-      assert_equal([">= 5.0", "< 7"], template.gem_version)
-      template.gem_version = "~> 6.0"
-      assert_equal(["~> 6.0"], template.gem_version)
-      template.gem_version = ["~> 5.14.0", "< 6.0"]
-      assert_equal(["~> 5.14.0", "< 6.0"], template.gem_version)
-      template.gem_version = nil
-      assert_equal([">= 5.0", "< 7"], template.gem_version)
+    it "sets the minitest gem version" do
+      assert_equal([">= 5.0", "< 7"], template.gem_dependencies["minitest"])
+      template.minitest = "~> 6.0"
+      assert_equal(["~> 6.0"], template.gem_dependencies["minitest"])
+      template.minitest = ["~> 5.14.0", "< 6.0"]
+      assert_equal(["~> 5.14.0", "< 6.0"], template.gem_dependencies["minitest"])
+      template.minitest = nil
+      assert_equal([">= 5.0", "< 7"], template.gem_dependencies["minitest"])
+    end
+
+    it "sets the minitest-mock gem version" do
+      refute_includes(template.gem_dependencies, "minitest-mock")
+      template.minitest_mock = "= 5.27.0"
+      assert_equal(["= 5.27.0"], template.gem_dependencies["minitest-mock"])
+      template.minitest_mock = [">= 5.27", "< 5.28"]
+      assert_equal([">= 5.27", "< 5.28"], template.gem_dependencies["minitest-mock"])
+      template.minitest_mock = true
+      assert_equal(["~> 5.27"], template.gem_dependencies["minitest-mock"])
+      template.minitest_mock = nil
+      refute_includes(template.gem_dependencies, "minitest-mock")
+    end
+
+    it "sets the minitest-focus gem version" do
+      refute_includes(template.gem_dependencies, "minitest-focus")
+      template.minitest_focus = "= 1.4.1"
+      assert_equal(["= 1.4.1"], template.gem_dependencies["minitest-focus"])
+      template.minitest_focus = [">= 1.4", "< 1.5"]
+      assert_equal([">= 1.4", "< 1.5"], template.gem_dependencies["minitest-focus"])
+      template.minitest_focus = true
+      assert_equal(["~> 1.4", ">= 1.4.1"], template.gem_dependencies["minitest-focus"])
+      template.minitest_focus = nil
+      refute_includes(template.gem_dependencies, "minitest-focus")
+    end
+
+    it "sets the minitest-rg gem version" do
+      refute_includes(template.gem_dependencies, "minitest-rg")
+      template.minitest_rg = "= 5.4.0"
+      assert_equal(["= 5.4.0"], template.gem_dependencies["minitest-rg"])
+      template.minitest_rg = [">= 5.4", "< 5.5"]
+      assert_equal([">= 5.4", "< 5.5"], template.gem_dependencies["minitest-rg"])
+      template.minitest_rg = true
+      assert_equal(["~> 5.4"], template.gem_dependencies["minitest-rg"])
+      template.minitest_rg = nil
+      refute_includes(template.gem_dependencies, "minitest-rg")
+    end
+
+    it "sets arbitrary gem versions" do
+      assert_equal([">= 5.0", "< 7"], template.gem_dependencies["minitest"])
+      refute_includes(template.gem_dependencies, "minitest-mock")
+      refute_includes(template.gem_dependencies, "toys")
+      template.update_gems({"minitest" => "~> 6.0", "minitest-mock" => "= 5.27.0", "toys" => "= 0.19.1"})
+      assert_equal(["~> 6.0"], template.gem_dependencies["minitest"])
+      assert_equal(["= 5.27.0"], template.gem_dependencies["minitest-mock"])
+      assert_equal(["= 0.19.1"], template.gem_dependencies["toys"])
+      template.update_gems({"minitest" => ["~> 5.14.0", "< 6.0"],
+                            "minitest-mock" => [">= 5.27", "< 5.28"],
+                            "toys" => [">= 0.19.1", "< 0.20"]})
+      assert_equal(["~> 5.14.0", "< 6.0"], template.gem_dependencies["minitest"])
+      assert_equal([">= 5.27", "< 5.28"], template.gem_dependencies["minitest-mock"])
+      assert_equal([">= 0.19.1", "< 0.20"], template.gem_dependencies["toys"])
+      template.update_gems({"minitest" => true, "minitest-mock" => true, "toys" => true})
+      assert_equal([">= 5.0", "< 7"], template.gem_dependencies["minitest"])
+      assert_equal(["~> 5.27"], template.gem_dependencies["minitest-mock"])
+      assert_equal([], template.gem_dependencies["toys"])
+      template.update_gems({"minitest" => nil, "minitest-mock" => nil, "toys" => nil})
+      assert_equal([">= 5.0", "< 7"], template.gem_dependencies["minitest"])
+      refute_includes(template.gem_dependencies, "minitest-mock")
+      refute_includes(template.gem_dependencies, "toys")
     end
 
     it "handles the seed field" do
@@ -76,15 +136,9 @@ describe "minitest template" do
       assert_equal(true, template.mt_compat)
     end
 
-    it "handles the gem_version field with bundler" do
+    it "unsets gem_dependencies when bundler is active" do
       template.use_bundler
-      assert_equal([], template.gem_version)
-      template.gem_version = "~> 5.1"
-      assert_equal(["~> 5.1"], template.gem_version)
-      template.gem_version = ["~> 5.14.0", "< 6.0"]
-      assert_equal(["~> 5.14.0", "< 6.0"], template.gem_version)
-      template.gem_version = nil
-      assert_equal([], template.gem_version)
+      assert_nil(template.gem_dependencies)
     end
 
     it "handles the bundler_settings field via the bundler writer" do
@@ -115,7 +169,11 @@ describe "minitest template" do
 
     it "honors constructor args" do
       template = template_class.new name: "hi",
-                                    gem_version: "~> 5.1",
+                                    minitest: "~> 6.0",
+                                    minitest_mock: [">= 5.27.0", "< 5.28"],
+                                    minitest_focus: "= 1.4.1",
+                                    minitest_rg: true,
+                                    gems: {"toys" => "= 1.9.1"},
                                     libs: "src",
                                     files: "test_files/**/*_test.rb",
                                     seed: 1234,
@@ -123,13 +181,20 @@ describe "minitest template" do
                                     warnings: false,
                                     context_directory: "/path/to/context"
       assert_equal("hi", template.name)
-      assert_equal(["~> 5.1"], template.gem_version)
       assert_equal(["src"], template.libs)
       assert_equal(["test_files/**/*_test.rb"], template.files)
       assert_equal(1234, template.seed)
       assert_equal(true, template.verbose)
       assert_equal(false, template.warnings)
       assert_equal("/path/to/context", template.context_directory)
+      expected_gems = {
+        "minitest" => ["~> 6.0"],
+        "minitest-focus" => ["= 1.4.1"],
+        "minitest-mock" => [">= 5.27.0", "< 5.28"],
+        "minitest-rg" => ["~> 5.4"],
+        "toys" => ["= 1.9.1"],
+      }
+      assert_equal(expected_gems, template.gem_dependencies)
     end
   end
 
@@ -149,6 +214,7 @@ describe "minitest template" do
         assert_equal(0, cli.run("test"))
       end
       assert_match(/0 failures/, out)
+      assert_match(/0 errors/, out)
     end
 
     it "runs failing tests" do
@@ -161,6 +227,19 @@ describe "minitest template" do
         assert_equal(1, cli.run("test"))
       end
       assert_match(/1 failure/, out)
+    end
+
+    it "chooses files" do
+      dir = cases_dir
+      loader.add_block do
+        set_context_directory dir
+        expand :minitest, files: "multiple/*.rb"
+      end
+      out, _err = capture_subprocess_io do
+        assert_equal(0, cli.run("test", "multiple/bar.rb"))
+      end
+      assert_match(/0 failures/, out)
+      assert_match(/0 errors/, out)
     end
 
     it "honors context_directory argument" do
@@ -185,6 +264,7 @@ describe "minitest template" do
         assert_equal(expected_failures, cli.run("test"))
       end
       assert_match(/#{expected_failures} failure/, out)
+      assert_match(/0 errors/, out)
     end
 
     it "sets MT_COMPAT" do
@@ -203,6 +283,7 @@ describe "minitest template" do
         ENV["MT_COMPAT"] = old_mt_compat
       end
       assert_match(/0 failures/, out)
+      assert_match(/0 errors/, out)
     end
 
     it "clears MT_COMPAT" do
@@ -221,6 +302,7 @@ describe "minitest template" do
         ENV["MT_COMPAT"] = old_mt_compat
       end
       assert_match(/1 failure/, out)
+      assert_match(/0 errors/, out)
     end
 
     it "supports input streams" do
@@ -231,6 +313,38 @@ describe "minitest template" do
         controller.in.puts "hello"
       end
       assert(result.success?)
+      assert_match(/0 failures/, result.captured_out)
+      assert_match(/0 errors/, result.captured_out)
+    end
+
+    it "does not load minitest-focus by default" do
+      result = ::Bundler.with_unbundled_env do
+        dir = "#{cases_dir}/focus"
+        args = [Toys.executable_path, "test-without"]
+        exec_service.exec_ruby(args, chdir: dir, out: :capture, err: :capture)
+      end
+      assert_equal(1, result.exit_code)
+      assert_match(/undefined/, result.captured_err)
+    end
+
+    it "loads minitest-focus directly" do
+      result = ::Bundler.with_unbundled_env do
+        dir = "#{cases_dir}/focus"
+        args = [Toys.executable_path, "test-direct"]
+        exec_service.exec_ruby(args, chdir: dir, out: :capture, err: :capture)
+      end
+      assert_equal(0, result.exit_code)
+      assert_match(/0 failures/, result.captured_out)
+      assert_match(/0 errors/, result.captured_out)
+    end
+
+    it "loads minitest-focus from bundler" do
+      result = ::Bundler.with_unbundled_env do
+        dir = "#{cases_dir}/focus"
+        args = [Toys.executable_path, "test-bundle"]
+        exec_service.exec_ruby(args, chdir: dir, out: :capture, err: :capture)
+      end
+      assert_equal(0, result.exit_code)
       assert_match(/0 failures/, result.captured_out)
       assert_match(/0 errors/, result.captured_out)
     end


### PR DESCRIPTION
change(toys)!: Toys::Templates::Minitest::DEFAULT_GEM_VERSION_REQUIREMENTS is now a hash that covers multiple gems rather than just the minitest gem