### PR TITLE
release: Release 2 items

### DIFF
--- a/toys-ci/CHANGELOG.md
+++ b/toys-ci/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.2.0 / 2026-05-05
+
+* BREAKING CHANGE: Template classes no longer automatically include `Toys::Context::Key`. This behavior was undocumented and inconsistent between different ways of defining templates.
+* ADDED: The `:gems` mixin provides a context key for retrieving the underlying `Toys::Utils::Gems` service object
+* ADDED: The `:gems` mixin provides an explicit `Toys::Utils::Gems::ClassMethods` module defining the directives added to the tool class
+* ADDED: The `activate` and `bundle` methods in the Gems utility now return useful results
+* FIXED: Template classes no longer automatically include `Toys::Context::Key`. This behavior was undocumented and inconsistent between different ways of defining templates.
+* DOCS: Updates to readme and user guide documentation
+* DOCS: Various documentation updates
+
 ### v0.1.0 / 2026-03-11
 
 * Initial release

--- a/toys-ci/CHANGELOG.md
+++ b/toys-ci/CHANGELOG.md
@@ -1,14 +1,8 @@
 # Release History
 
-### v0.2.0 / 2026-05-05
+### v0.1.1 / 2026-05-05
 
-* BREAKING CHANGE: Template classes no longer automatically include `Toys::Context::Key`. This behavior was undocumented and inconsistent between different ways of defining templates.
-* ADDED: The `:gems` mixin provides a context key for retrieving the underlying `Toys::Utils::Gems` service object
-* ADDED: The `:gems` mixin provides an explicit `Toys::Utils::Gems::ClassMethods` module defining the directives added to the tool class
-* ADDED: The `activate` and `bundle` methods in the Gems utility now return useful results
-* FIXED: Template classes no longer automatically include `Toys::Context::Key`. This behavior was undocumented and inconsistent between different ways of defining templates.
-* DOCS: Updates to readme and user guide documentation
-* DOCS: Various documentation updates
+* DOCS: Minor documentation updates
 
 ### v0.1.0 / 2026-03-11
 

--- a/toys-ci/lib/toys/ci/version.rb
+++ b/toys-ci/lib/toys/ci/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys CI system.
     # @return [String]
     #
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/toys-ci/lib/toys/ci/version.rb
+++ b/toys-ci/lib/toys/ci/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys CI system.
     # @return [String]
     #
-    VERSION = "0.2.0"
+    VERSION = "0.1.1"
   end
 end

--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.9.1 / 2026-05-05
 
-* DOCS: Updates to readme and user guide documentation
+* DOCS: Minor documentation updates
 
 ### v0.9.0 / 2026-03-23
 

--- a/toys-release/CHANGELOG.md
+++ b/toys-release/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.9.1 / 2026-05-05
+
+* DOCS: Updates to readme and user guide documentation
+
 ### v0.9.0 / 2026-03-23
 
 * ADDED: Provided a `version_from_code` setting that allows the current VERSION constant to determine the release version

--- a/toys-release/lib/toys/release/version.rb
+++ b/toys-release/lib/toys/release/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys release system.
     # @return [String]
     #
-    VERSION = "0.9.0"
+    VERSION = "0.9.1"
   end
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys-ci 0.1.1** (was 0.1.0)
 *  **toys-release 0.9.1** (was 0.9.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys-ci

 *  DOCS: Minor documentation updates

----

## toys-release

 *  DOCS: Minor documentation updates

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys": null,
    "toys-core": null,
    "toys-ci": null,
    "toys-release": null,
    "common-tools": null
  },
  "request_sha": "cc9c732f8c4aab0e4199f0f3908e98a422d085b3"
}
```
