### PR TITLE
chore(toys-core): FlagGroup#validation_errors returns messages, not errors

### DIFF
--- a/toys-core/lib/toys/arg_parser.rb
+++ b/toys-core/lib/toys/arg_parser.rb
@@ -653,7 +653,8 @@ module Toys
 
     def finish_flag_groups
       @tool.flag_groups.each do |group|
-        @errors += Array(group.validation_errors(@seen_flag_keys))
+        messages = Array(group.validation_errors(@seen_flag_keys))
+        @errors += messages.map { |message| FlagGroupConstraintError.new(message) }
       end
     end
 

--- a/toys-core/lib/toys/flag_group.rb
+++ b/toys-core/lib/toys/flag_group.rb
@@ -179,8 +179,9 @@ module Toys
       #
       # @param _seen [Array<Object>] A list of the keys of the flags actually
       #     passed to the invocation
-      # @return [Array<ArgParser::FlagGroupConstraintError>] A list of errors
-      #     to raise, or the empty array if no errors were found
+      # @return [Array<String>] A list of messages describing the constraints
+      #     that were not satisfied, or the empty array if all were satisfied.
+      #     The caller is responsible for converting these into errors.
       #
       def validation_errors(_seen)
         raise ::NotImplementedError
@@ -198,8 +199,7 @@ module Toys
         results = []
         flags.each do |flag|
           unless seen.include?(flag.key)
-            str = "Flag \"#{flag.display_name}\" is required."
-            results << ArgParser::FlagGroupConstraintError.new(str)
+            results << "Flag \"#{flag.display_name}\" is required."
           end
         end
         results
@@ -233,10 +233,10 @@ module Toys
         if seen_names.size > 1
           str = "Exactly one flag out of group #{summary} is required, but #{seen_names.size}" \
                 " were provided: #{seen_names.inspect}."
-          [ArgParser::FlagGroupConstraintError.new(str)]
+          [str]
         elsif seen_names.empty?
           str = "Exactly one flag out of group #{summary} is required, but none were provided."
-          [ArgParser::FlagGroupConstraintError.new(str)]
+          [str]
         else
           []
         end
@@ -258,7 +258,7 @@ module Toys
         if seen_names.size > 1
           str = "At most one flag out of group #{summary} is required, but #{seen_names.size}" \
                 " were provided: #{seen_names.inspect}."
-          [ArgParser::FlagGroupConstraintError.new(str)]
+          [str]
         else
           []
         end
@@ -275,7 +275,7 @@ module Toys
       def validation_errors(seen)
         return [] if flags.any? { |flag| seen.include?(flag.key) }
         str = "At least one flag out of group #{summary} is required, but none were provided."
-        [ArgParser::FlagGroupConstraintError.new(str)]
+        [str]
       end
     end
   end

--- a/toys-core/test/test_flag_group.rb
+++ b/toys-core/test/test_flag_group.rb
@@ -12,18 +12,6 @@ describe Toys::FlagGroup do
     group << flag
   end
 
-  def assert_errors_include(expected, errors)
-    return if errors.any? do |err|
-      case expected
-      when ::String
-        err.message == expected
-      when ::Class
-        err.is_a?(expected)
-      end
-    end
-    flunk("Errors #{errors.inspect} did not include expected #{expected.inspect}")
-  end
-
   describe "create" do
     describe "type resolution" do
       it "defaults to Optional when type is omitted" do
@@ -136,8 +124,8 @@ describe Toys::FlagGroup do
     it "fails to validate with a flag missing" do
       group = Toys::FlagGroup::Required.new(nil, nil, nil)
       add_flags(group)
-      assert_errors_include('Flag "--flag2" is required.',
-                            group.validation_errors([:flag1, :flag3]))
+      assert_includes(group.validation_errors([:flag1, :flag3]),
+                      'Flag "--flag2" is required.')
     end
   end
 
@@ -165,20 +153,20 @@ describe Toys::FlagGroup do
     it "fails to validate with no flags set" do
       group = Toys::FlagGroup::ExactlyOne.new(nil, nil, nil)
       add_flags(group)
-      assert_errors_include(
+      assert_includes(
+        group.validation_errors([]),
         'Exactly one flag out of group ["--flag1", "--flag2", "--flag3"] is required,' \
-          " but none were provided.",
-        group.validation_errors([])
+          " but none were provided."
       )
     end
 
     it "fails to validate with two flags set" do
       group = Toys::FlagGroup::ExactlyOne.new(nil, nil, nil)
       add_flags(group)
-      assert_errors_include(
+      assert_includes(
+        group.validation_errors([:flag1, :flag3]),
         'Exactly one flag out of group ["--flag1", "--flag2", "--flag3"] is required,' \
-          ' but 2 were provided: ["--flag1", "--flag3"].',
-        group.validation_errors([:flag1, :flag3])
+          ' but 2 were provided: ["--flag1", "--flag3"].'
       )
     end
   end
@@ -199,10 +187,10 @@ describe Toys::FlagGroup do
     it "fails to validate with two flags set" do
       group = Toys::FlagGroup::AtMostOne.new(nil, nil, nil)
       add_flags(group)
-      assert_errors_include(
+      assert_includes(
+        group.validation_errors([:flag1, :flag3]),
         'At most one flag out of group ["--flag1", "--flag2", "--flag3"] is required,' \
-          ' but 2 were provided: ["--flag1", "--flag3"].',
-        group.validation_errors([:flag1, :flag3])
+          ' but 2 were provided: ["--flag1", "--flag3"].'
       )
     end
   end
@@ -217,10 +205,10 @@ describe Toys::FlagGroup do
     it "fails to validate with no flags set" do
       group = Toys::FlagGroup::AtLeastOne.new(nil, nil, nil)
       add_flags(group)
-      assert_errors_include(
+      assert_includes(
+        group.validation_errors([]),
         'At least one flag out of group ["--flag1", "--flag2", "--flag3"] is required,' \
-          " but none were provided.",
-        group.validation_errors([])
+          " but none were provided."
       )
     end
 


### PR DESCRIPTION
FlagGroup reached upward into ArgParser solely to construct ArgParser::FlagGroupConstraintError, even though ArgParser is the caller of validation_errors and immediately collects the results. The private validation_errors API now returns message strings, and ArgParser wraps them into errors, so the flag group classes no longer depend on the argument parser.

No public API changes: ArgParser#errors still holds FlagGroupConstraintError instances with identical messages.