### PR TITLE
feat(toys-core): ToolDefinition#run_handler returns the delegate target for a delegating tool

### DIFF
--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -767,7 +767,9 @@ module Toys
       unless cli.loader.tool_defined?(target)
         raise ToolDefinitionError, "Delegate target not found: \"#{target.join(' ')}\""
       end
-      context.exit(cli.run(target + context[Context::Key::ARGS], delegated_from: context))
+      # Uses Context.exit rather than context.exit because a tool is allowed to
+      # override the exit method, and this control flow must not be intercepted.
+      Context.exit(cli.run(target + context[Context::Key::ARGS], delegated_from: context))
     end
 
     def execute_tool(tool, context, &block)

--- a/toys-core/lib/toys/cli.rb
+++ b/toys-core/lib/toys/cli.rb
@@ -732,15 +732,42 @@ module Toys
 
     def make_run_handler(tool)
       run_handler = tool.run_handler
-      if run_handler.is_a?(::Symbol)
+      case run_handler
+      when ::Symbol
         proc do |context|
           context.send(run_handler)
+        end
+      when ::Array
+        proc do |context|
+          run_delegation(context, run_handler)
         end
       else
         proc do |context|
           context.instance_exec(&run_handler)
         end
       end
+    end
+
+    # Runs the delegate target of a delegating tool. The tool's run handler is
+    # the full name of the target, and the current context is passed along as
+    # the delegating context.
+    def run_delegation(context, target)
+      path = [target.join(" ").inspect]
+      walk_context = context
+      until walk_context.nil?
+        name = walk_context[Context::Key::TOOL_NAME]
+        path << name.join(" ").inspect
+        if name == target
+          raise ToolDefinitionError, "Delegation loop: #{path.join(' <- ')}"
+        end
+        walk_context = walk_context[Context::Key::DELEGATED_FROM]
+      end
+      cli = context[Context::Key::CLI]
+      cli.loader.load_for_prefix(target)
+      unless cli.loader.tool_defined?(target)
+        raise ToolDefinitionError, "Delegate target not found: \"#{target.join(' ')}\""
+      end
+      context.exit(cli.run(target + context[Context::Key::ARGS], delegated_from: context))
     end
 
     def execute_tool(tool, context, &block)

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -501,8 +501,17 @@ module Toys
     # however, typically a tool is made non-runnable simply by leaving the run
     # handler set to `:run` and not defining the method.
     #
+    # Additionally, if this tool delegates to another tool, the run handler is
+    # the full name of the delegate target, as an array of strings. Note that
+    # this value cannot be assigned through {#run_handler=}, which accepts only
+    # a proc, symbol, or nil. Delegation is configured by calling
+    # {#delegate_to}, which sets this attribute along with the rest of the
+    # delegation state. The getter and setter are thus not symmetrical: the
+    # getter can return an array that the setter would reject.
+    #
     # @return [Proc] if the run handler is defined as a Proc
     # @return [Symbol] if the run handler is defined as a method
+    # @return [Array<String>] if this tool delegates to another tool
     # @return [nil] if the tool is explicitly made non-runnable
     #
     attr_reader :run_handler
@@ -590,7 +599,7 @@ module Toys
     # @return [true,false]
     #
     def runnable?
-      @run_handler.is_a?(::Proc) ||
+      @run_handler.is_a?(::Proc) || @run_handler.is_a?(::Array) ||
         (@run_handler.is_a?(::Symbol) && tool_class.public_instance_methods(false).include?(@run_handler))
     end
 
@@ -1297,6 +1306,11 @@ module Toys
     # however, typically a tool is made non-runnable simply by leaving the run
     # handler set to `:run` and not defining the method.
     #
+    # This setter does not accept an array, even though {#run_handler} may
+    # return one for a delegating tool. Delegation involves more state than
+    # just the run handler, so it must be configured by calling
+    # {#delegate_to}.
+    #
     # @param handler [Proc,Symbol,nil] the run handler
     #
     def run_handler=(handler)
@@ -1461,7 +1475,8 @@ module Toys
               " some implementation has already been created for it."
       end
       disable_argument_parsing
-      self.run_handler = make_delegation_run_handler(target)
+      check_definition_state(is_method: true)
+      @run_handler = target
       self.completion = DefaultCompletion.new(delegation_target: target)
       @delegate_target = target
       self
@@ -1554,27 +1569,6 @@ module Toys
         proc { middleware.config(self, loader, &next_config) }
       else
         next_config
-      end
-    end
-
-    def make_delegation_run_handler(target)
-      lambda do
-        path = [target.join(" ").inspect]
-        walk_context = self
-        until walk_context.nil?
-          name = walk_context[::Toys::Context::Key::TOOL_NAME]
-          path << name.join(" ").inspect
-          if name == target
-            raise ToolDefinitionError, "Delegation loop: #{path.join(' <- ')}"
-          end
-          walk_context = walk_context[::Toys::Context::Key::DELEGATED_FROM]
-        end
-        cli = self[::Toys::Context::Key::CLI]
-        cli.loader.load_for_prefix(target)
-        unless cli.loader.tool_defined?(target)
-          raise ToolDefinitionError, "Delegate target not found: \"#{target.join(' ')}\""
-        end
-        exit(cli.run(target + self[::Toys::Context::Key::ARGS], delegated_from: self))
       end
     end
 

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -1460,7 +1460,14 @@ module Toys
     ##
     # Causes this tool to delegate to another tool.
     #
-    # @param target [Array<String>] The full path to the delegate tool.
+    # This sets {#run_handler} to the name of the target, disables argument
+    # parsing, and replaces {#completion} with one that defers to the target.
+    # It is the only supported way to configure delegation; {#run_handler=}
+    # does not accept a target name.
+    #
+    # @param target [Array<String>] The full path to the delegate tool. The
+    #     elements are converted to strings, and a frozen copy of the array is
+    #     retained.
     # @return [self]
     #
     def delegate_to(target)
@@ -1475,7 +1482,7 @@ module Toys
               "Cannot delegate tool #{display_name.inspect} because" \
               " some implementation has already been created for it."
       end
-      target = target.dup.freeze
+      target = target.map { |word| word.to_s.dup.freeze }.freeze
       disable_argument_parsing
       check_definition_state(is_method: true)
       @run_handler = target

--- a/toys-core/lib/toys/tool_definition.rb
+++ b/toys-core/lib/toys/tool_definition.rb
@@ -502,12 +502,12 @@ module Toys
     # handler set to `:run` and not defining the method.
     #
     # Additionally, if this tool delegates to another tool, the run handler is
-    # the full name of the delegate target, as an array of strings. Note that
-    # this value cannot be assigned through {#run_handler=}, which accepts only
-    # a proc, symbol, or nil. Delegation is configured by calling
-    # {#delegate_to}, which sets this attribute along with the rest of the
-    # delegation state. The getter and setter are thus not symmetrical: the
-    # getter can return an array that the setter would reject.
+    # the full name of the delegate target, as an array of strings. This array
+    # may not be modified. Note also that this value cannot be assigned through
+    # {#run_handler=}, which accepts only a proc, symbol, or nil. Delegation is
+    # configured by calling {#delegate_to}, which sets this attribute along
+    # with the rest of the delegation state. The getter and setter are thus not
+    # symmetrical: the getter can return an array that the setter would reject.
     #
     # @return [Proc] if the run handler is defined as a Proc
     # @return [Symbol] if the run handler is defined as a method
@@ -533,6 +533,7 @@ module Toys
 
     ##
     # The full name of the delegate target, if any.
+    # This array may not be modified.
     #
     # @return [Array<String>] if this tool delegates
     # @return [nil] if this tool does not delegate
@@ -1474,6 +1475,7 @@ module Toys
               "Cannot delegate tool #{display_name.inspect} because" \
               " some implementation has already been created for it."
       end
+      target = target.dup.freeze
       disable_argument_parsing
       check_definition_state(is_method: true)
       @run_handler = target

--- a/toys-core/test/test_cli.rb
+++ b/toys-core/test/test_cli.rb
@@ -195,6 +195,104 @@ describe Toys::CLI do
     end
   end
 
+  describe "delegation" do
+    it "executes the delegate" do
+      cli.add_config_block do
+        tool "foo" do
+          tool "bar" do
+            def run
+              exit(4)
+            end
+          end
+          delegate_to ["foo", "bar"]
+        end
+      end
+      assert_equal(4, cli.run("foo"))
+    end
+
+    it "passes arguments to the delegate" do
+      test = self
+      cli.add_config_block do
+        tool "foo" do
+          tool "bar" do
+            flag :foo, "--foo=VAL"
+            to_run do
+              test.assert_equal("hello", get(:foo))
+              exit(4)
+            end
+          end
+          delegate_to ["foo", "bar"]
+        end
+      end
+      assert_equal(4, cli.run("foo", "--foo", "hello"))
+    end
+
+    it "executes the delegate when the tool has a private exit method" do
+      exit_mixin = ::Module.new do
+        private
+
+        def exit(code = 0)
+          Toys::Context.exit(code)
+        end
+      end
+      cli.add_config_block do
+        tool "foo" do
+          tool "bar" do
+            def run
+              exit(4)
+            end
+          end
+          delegate_to ["foo", "bar"]
+          include exit_mixin
+        end
+      end
+      assert_equal(4, cli.run("foo"))
+    end
+
+    it "delegates to a namespace" do
+      cli.add_config_block do
+        tool "foo" do
+          tool "bar" do
+            def run
+              exit(4)
+            end
+          end
+        end
+        tool "boo" do
+          delegate_to ["foo"]
+        end
+      end
+      assert_equal(4, cli.run("boo", "bar"))
+    end
+
+    it "detects dangling references" do
+      cli.add_config_block do
+        tool "foo" do
+          delegate_to ["boo"]
+        end
+      end
+      error = assert_raises(Toys::ContextualError) do
+        cli.run("foo")
+      end
+      assert_equal("Delegate target not found: \"boo\"", error.cause.message)
+    end
+
+    it "detects circular references" do
+      cli.add_config_block do
+        tool "foo" do
+          delegate_to ["boo"]
+        end
+        tool "boo" do
+          delegate_to ["foo"]
+        end
+      end
+      error = assert_raises(Toys::ContextualError) do
+        cli.run("foo")
+      end
+      assert_equal("Delegation loop: \"foo\" <- \"boo\" <- \"foo\"", error.cause.message)
+    end
+  end
+
   describe "error handling" do
     it "raises the error by default" do
       cli.add_config_block do

--- a/toys-core/test/test_tool_definition.rb
+++ b/toys-core/test/test_tool_definition.rb
@@ -1205,6 +1205,16 @@ describe Toys::ToolDefinition do
       assert_equal(true, tool.argument_parsing_disabled?)
     end
 
+    it "sets the run handler to the target" do
+      tool.delegate_to(["bar"])
+      assert_equal(["bar"], tool.run_handler)
+    end
+
+    it "is runnable" do
+      tool.delegate_to(["bar"])
+      assert(tool.runnable?)
+    end
+
     it "does not override an existing description" do
       tool.desc = "Existing description"
       tool.delegate_to(["bar"])
@@ -1342,6 +1352,13 @@ describe Toys::ToolDefinition do
         end
       end
       refute(tool.runnable?)
+    end
+
+    it "cannot be set to an array" do
+      error = assert_raises(Toys::ToolDefinitionError) do
+        tool.run_handler = ["bar"]
+      end
+      assert_equal("Run handler must be a proc or symbol", error.message)
     end
   end
 

--- a/toys-core/test/test_tool_definition.rb
+++ b/toys-core/test/test_tool_definition.rb
@@ -1298,67 +1298,6 @@ describe Toys::ToolDefinition do
         tool.delegate_to(["bar"])
       end
     end
-
-    it "executes the delegate" do
-      subtool.run_handler = proc do
-        exit(4)
-      end
-      tool.delegate_to([tool_name, subtool_name])
-      assert_equal(4, cli.run(tool_name))
-    end
-
-    it "passes arguments to the delegate" do
-      test = self
-      subtool.add_flag(:foo, ["--foo=VAL"])
-      subtool.run_handler = proc do
-        test.assert_equal("hello", get(:foo))
-        exit(4)
-      end
-      tool.delegate_to([tool_name, subtool_name])
-      assert_equal(4, cli.run(tool_name, "--foo", "hello"))
-    end
-
-    it "executes the delegate when the tool has a private exit method" do
-      mixin = ::Module.new do
-        private
-
-        def exit(code = 0)
-          Toys::Context.exit(code)
-        end
-      end
-      subtool.run_handler = proc do
-        exit(4)
-      end
-      tool.delegate_to([tool_name, subtool_name])
-      tool.tool_class.include(mixin)
-      assert_equal(4, cli.run(tool_name))
-    end
-
-    it "delegates to a namespace" do
-      subtool.run_handler = proc do
-        exit(4)
-      end
-      tool2.delegate_to([tool_name])
-      assert_equal(4, cli.run(tool2_name, subtool_name))
-    end
-
-    it "detects dangling references" do
-      tool.delegate_to([tool2_name])
-      error = assert_raises(Toys::ContextualError) do
-        cli.run(tool_name)
-      end
-      assert_equal("Delegate target not found: \"#{tool2_name}\"", error.cause.message)
-    end
-
-    it "detects circular references" do
-      tool.delegate_to([tool2_name])
-      tool2.delegate_to([tool_name])
-      error = assert_raises(Toys::ContextualError) do
-        cli.run(tool_name)
-      end
-      assert_equal("Delegation loop: \"#{tool_name}\" <- \"#{tool2_name}\" <- \"#{tool_name}\"",
-                   error.cause.message)
-    end
   end
 
   describe "run handler" do

--- a/toys-core/test/test_tool_definition.rb
+++ b/toys-core/test/test_tool_definition.rb
@@ -1229,6 +1229,29 @@ describe Toys::ToolDefinition do
       assert_equal(["bar"], tool.run_handler)
     end
 
+    it "freezes the elements of the target" do
+      tool.delegate_to([+"bar"])
+      assert(tool.delegate_target[0].frozen?)
+    end
+
+    it "does not retain the strings passed by the caller" do
+      word = +"bar"
+      tool.delegate_to([word])
+      word << "baz"
+      assert_equal(["bar"], tool.delegate_target)
+    end
+
+    it "normalizes the target elements to strings" do
+      tool.delegate_to([:bar])
+      assert_equal(["bar"], tool.delegate_target)
+    end
+
+    it "shares one target array with the run handler and the completion" do
+      tool.delegate_to(["bar"])
+      assert_same(tool.delegate_target, tool.run_handler)
+      assert_same(tool.delegate_target, tool.completion.delegation_target)
+    end
+
     it "does not override an existing description" do
       tool.desc = "Existing description"
       tool.delegate_to(["bar"])
@@ -1293,6 +1316,22 @@ describe Toys::ToolDefinition do
       end
       tool.delegate_to([tool_name, subtool_name])
       assert_equal(4, cli.run(tool_name, "--foo", "hello"))
+    end
+
+    it "executes the delegate when the tool has a private exit method" do
+      mixin = ::Module.new do
+        private
+
+        def exit(code = 0)
+          Toys::Context.exit(code)
+        end
+      end
+      subtool.run_handler = proc do
+        exit(4)
+      end
+      tool.delegate_to([tool_name, subtool_name])
+      tool.tool_class.include(mixin)
+      assert_equal(4, cli.run(tool_name))
     end
 
     it "delegates to a namespace" do

--- a/toys-core/test/test_tool_definition.rb
+++ b/toys-core/test/test_tool_definition.rb
@@ -1215,6 +1215,20 @@ describe Toys::ToolDefinition do
       assert(tool.runnable?)
     end
 
+    it "freezes the target" do
+      tool.delegate_to(["bar"])
+      assert(tool.delegate_target.frozen?)
+      assert(tool.run_handler.frozen?)
+    end
+
+    it "does not retain the array passed by the caller" do
+      target = ["bar"]
+      tool.delegate_to(target)
+      target << "baz"
+      assert_equal(["bar"], tool.delegate_target)
+      assert_equal(["bar"], tool.run_handler)
+    end
+
     it "does not override an existing description" do
       tool.desc = "Existing description"
       tool.delegate_to(["bar"])


### PR DESCRIPTION
For a tool that delegates to another tool, ToolDefinition#run_handler now returns the full name of the delegate target, as an array of strings. It previously returned a Proc that implemented the delegation. Code that inspects the run handler of a delegating tool, or that assumes the getter returns only a Proc, Symbol, or nil, must account for the new array case. ToolDefinition#runnable? now also treats an array run handler as runnable.

Note that run_handler= still accepts only a proc, symbol, or nil. Delegation involves additional state beyond the run handler, so it must be configured through delegate_to. The getter and setter are therefore not symmetrical, and this is documented on both.

This moves the delegation implementation to where the rest of the execution code lives. ToolDefinition previously built a lambda that walked the context chain, detected delegation loops, and invoked the CLI, which required the tool definition layer to reach upward into Toys::Context in four places. CLI#make_run_handler now recognizes the target array and runs the delegation itself, leaving ToolDefinition to record only that the tool delegates and to what.