### PR TITLE
feat: Allow a custom source list to be passed to StandardCLI

### DIFF
--- a/toys/lib/toys/standard_cli.rb
+++ b/toys/lib/toys/standard_cli.rb
@@ -81,10 +81,17 @@ module Toys
     # @param include_builtins [boolean] Add the builtin tools. Default is true.
     # @param cur_dir [String,nil] Starting search directory for sources.
     #     Defaults to the current working directory.
+    # @param source_list [Toys::SourceList,nil] An optional source list, used
+    #     to configure the resolvers (such as the git cache and the gems
+    #     utility) employed when sources are added. It is not intended for
+    #     seeding sources, because this class adds the standard paths after
+    #     the list is installed, meaning any sources already in the list would
+    #     take priority over the standard paths.
     #
     def initialize(custom_paths: nil,
                    include_builtins: true,
-                   cur_dir: nil)
+                   cur_dir: nil,
+                   source_list: nil)
       require "toys/utils/standard_ui"
       ui = Toys::Utils::StandardUI.new
       super(
@@ -94,6 +101,7 @@ module Toys
         extra_delimiters: EXTRA_DELIMITERS,
         middleware_stack: default_middleware_stack,
         template_lookup: default_template_lookup,
+        source_list: source_list,
         **ui.cli_args
       )
       if custom_paths

--- a/toys/test/test_standard_cli.rb
+++ b/toys/test/test_standard_cli.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "helper"
+require "toys/utils/exec"
+require "toys/utils/git_cache"
+require "fileutils"
+require "tmpdir"
+
+describe Toys::StandardCLI do
+  describe "source_list" do
+    let(:exec_tool) { Toys::Utils::Exec.new }
+    # Each test gets its own temp directory, so no test can see cache or repo
+    # state left behind by another, whether in this suite or elsewhere.
+    let(:tmp_dir) { Dir.mktmpdir("toys_standard_cli_test") }
+    let(:git_repo_dir) { File.join(tmp_dir, "repo") }
+    let(:local_remote) { File.join(git_repo_dir, ".git") }
+    let(:cache_dir) { File.join(tmp_dir, "cache") }
+    let(:custom_path) { File.join(tmp_dir, "custom") }
+    let(:xdg_cache_home) { File.join(tmp_dir, "xdg-cache") }
+    let(:default_cache_dir) { File.join(xdg_cache_home, "git-cache", "v1") }
+
+    def exec_git(*args)
+      result = exec_tool.exec(["git"] + args, out: :capture, err: :null)
+      assert(result.success?, "Git failed: #{args}")
+      result.captured_out
+    end
+
+    def commit_file(name, content)
+      Dir.chdir(git_repo_dir) do
+        File.open(name, "w") { |file| file.puts(content) }
+        exec_git("add", name)
+        exec_git("commit", "-m", "Add file #{name}")
+      end
+    end
+
+    before do
+      FileUtils.mkdir_p(git_repo_dir)
+      FileUtils.mkdir_p(custom_path)
+      Dir.chdir(git_repo_dir) do
+        exec_git("init")
+      end
+      commit_file("greet.rb", "def run\n  puts 'Hello from git'\nend\n")
+      @old_xdg_cache_home = ENV["XDG_CACHE_HOME"]
+      ENV["XDG_CACHE_HOME"] = xdg_cache_home
+    end
+
+    after do
+      ENV["XDG_CACHE_HOME"] = @old_xdg_cache_home
+      # Cached sources are made read-only, so restore write access before
+      # removing the temp directory. Removal also races with the maintenance
+      # process that git spawns detached after a fetch, in two ways. It can
+      # write new pack files into a directory that rm_rf has already emptied,
+      # which leaves the tree in place without raising anything. It can also
+      # delete an objects directory between the moment chmod_R lists it and
+      # the moment it descends into it, which raises out of the traversal
+      # because `force` covers only the chmod of each entry, not the walk. So
+      # swallow the walk errors, and retry until the tree is really gone.
+      5.times do
+        begin
+          FileUtils.chmod_R("u+w", tmp_dir, force: true)
+        rescue SystemCallError
+          # Fall through to the removal attempt, then try again.
+        end
+        FileUtils.rm_rf(tmp_dir)
+        break unless File.exist?(tmp_dir)
+        sleep(0.1)
+      end
+    end
+
+    it "resolves git sources using a custom git cache" do
+      git_cache = Toys::Utils::GitCache.new(cache_dir: cache_dir)
+      source_list = Toys::SourceList.new(git_cache: git_cache)
+      cli = Toys::StandardCLI.new(custom_paths: custom_path,
+                                  include_builtins: false,
+                                  source_list: source_list)
+      cli.add_source_git(local_remote)
+      out, _err = capture_subprocess_io do
+        assert_equal(0, cli.run("greet"))
+      end
+      assert_includes(out, "Hello from git")
+      refute_empty(Dir.children(cache_dir))
+      refute(File.exist?(default_cache_dir))
+    end
+  end
+end


### PR DESCRIPTION
Adds a `source_list:` keyword to `Toys::StandardCLI#initialize`, forwarded unchanged to `Toys::CLI#initialize`. This lets a caller configure the resolvers (git cache, gems utility) used when sources are added, which in particular lets tests resolve git sources without writing into the real user cache.