### PR TITLE
release: Release 3 items

### DIFF
--- a/toys-ci/CHANGELOG.md
+++ b/toys-ci/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.2.0 / 2026-09-09
+
+* ADDED: Add SourceSpec, an unresolved description of a tool source
+
 ### v0.1.1 / 2026-05-05
 
 * DOCS: Minor documentation updates

--- a/toys-ci/lib/toys/ci/version.rb
+++ b/toys-ci/lib/toys/ci/version.rb
@@ -6,6 +6,6 @@ module Toys
     # Current version of the Toys CI system.
     # @return [String]
     #
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Release History
 
+### v0.23.0 / 2026-09-09
+
+* BREAKING CHANGE: Refactor CLI to extract a Runnable class and limit back-references to CLI
+* BREAKING CHANGE: Extract tool name splitting from Loader into a public ToolNameSplitter class
+* BREAKING CHANGE: Split SourceListBuilder out of Loader
+* BREAKING CHANGE: Ensure a context directory is always available
+* BREAKING CHANGE: Improvements to error rendering in the standard error handler
+* BREAKING CHANGE: Replace SourceInfo's flat git and gem fields with an origin object
+* BREAKING CHANGE: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
+* ADDED: Add treat_unknown_flags_as_args directive
+* ADDED: CLI#child can copy loader sources
+* ADDED: Added CLI#add_config_gem and CLI#add_config_git
+* ADDED: Add --gem flag to the do builtin
+* ADDED: ToolDefinition#run_handler returns the delegate target for a delegating tool
+* ADDED: Context keys and sentinels now display their names in diagnostic output
+* ADDED: Extract tool name splitting from Loader into a public ToolNameSplitter class
+* ADDED: Rename ContextualError#config_path and config_line to tool_file_path and tool_file_line
+* ADDED: Replace SourceListBuilder with SourceList that is passed directly to the Loader
+* ADDED: Add SourceSpec, an unresolved description of a tool source
+* ADDED: Ensure a context directory is always available
+* ADDED: The ApplyConfig middleware can now be provided independently in addition to from an existing source
+* ADDED: Improvements to error rendering in the standard error handler
+* ADDED: Replace SourceInfo's flat git and gem fields with an origin object
+* FIXED: Fixed a "circular causes" error on certain versions of JRuby
+* FIXED: Loader#add_path_set raises immediately for a relative path that is not a readable config
+* FIXED: More minor loader cleanup
+* FIXED: Identify flags by definition rather than by context key when validating flag groups
+* FIXED: Include git_cache 0.1.2 which includes a fix for git auto maintenance races
+* FIXED: Toys::Tool subclasses now have their own source info
+* FIXED: Raise ToolDefinitionError when attempting to reset a tool previously defined by subclassing Toys::Tool
+* FIXED: Preserve dependency provenance and require: in the modified gemfile
+* FIXED: Honor BUNDLE_LOCKFILE and stop leaking it from the modified bundle
+* FIXED: Various minor fixes
+* FIXED: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
+* DOCS: Fixed a few links in the reference documentation
+* DOCS: Fix typos in the flag parsing directive documentation
+* DOCS: Classify Middleware in the support layer
+* DOCS: Update ToolDefinition docs with a note about the two-phase lifecycle
+
 ### v0.22.0 / 2026-05-05
 
 Toys-core 0.22 is a major release focused on polish and cleanup in preparation for version 1.0. It includes a number of small breaking changes where needed to clean up the interfaces.

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,7 +9,7 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.22.0"
+    VERSION = "0.23.0"
   end
 
   ##

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Release History
 
+### v0.23.0 / 2026-09-09
+
+* BREAKING CHANGE: Refactor CLI to extract a Runnable class and limit back-references to CLI
+* BREAKING CHANGE: Extract tool name splitting from Loader into a public ToolNameSplitter class
+* BREAKING CHANGE: Split SourceListBuilder out of Loader
+* BREAKING CHANGE: Ensure a context directory is always available
+* BREAKING CHANGE: Improvements to error rendering in the standard error handler
+* BREAKING CHANGE: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
+* ADDED: Add treat_unknown_flags_as_args directive
+* ADDED: CLI#child can copy loader sources
+* ADDED: Added CLI#add_config_gem and CLI#add_config_git
+* ADDED: Add --gem flag to the do builtin
+* ADDED: Extract tool name splitting from Loader into a public ToolNameSplitter class
+* ADDED: Rename ContextualError#config_path and config_line to tool_file_path and tool_file_line
+* ADDED: Allow a custom source list to be passed to StandardCLI
+* ADDED: Support `--path` and `--git` flags in `toys do`
+* ADDED: Add SourceSpec, an unresolved description of a tool source
+* ADDED: Ensure a context directory is always available
+* ADDED: Improvements to error rendering in the standard error handler
+* FIXED: Various minor fixes
+* FIXED: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
+* DOCS: Fixed a few links in the reference documentation
+* DOCS: Fix typos in the flag parsing directive documentation
+* DOCS: Classes from toys-core display their notice at the end instead of the beginning of their description
+
 ### v0.22.0 / 2026-05-05
 
 Toys 0.22 is a major release focused on polish and cleanup in preparation for version 1.0. It includes a number of small breaking changes where needed to clean up the interfaces. (Note that many of the changes listed below are actually in the `toys-core` gem.)

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.22.0"
+  VERSION = "0.23.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.23.0** (was 0.22.0)
 *  **toys-core 0.23.0** (was 0.22.0)
 *  **toys-ci 0.2.0** (was 0.1.1)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  BREAKING CHANGE: Refactor CLI to extract a Runnable class and limit back-references to CLI
 *  BREAKING CHANGE: Extract tool name splitting from Loader into a public ToolNameSplitter class
 *  BREAKING CHANGE: Split SourceListBuilder out of Loader
 *  BREAKING CHANGE: Ensure a context directory is always available
 *  BREAKING CHANGE: Improvements to error rendering in the standard error handler
 *  BREAKING CHANGE: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
 *  ADDED: Add treat_unknown_flags_as_args directive
 *  ADDED: CLI#child can copy loader sources
 *  ADDED: Added CLI#add_config_gem and CLI#add_config_git
 *  ADDED: Add --gem flag to the do builtin
 *  ADDED: Extract tool name splitting from Loader into a public ToolNameSplitter class
 *  ADDED: Rename ContextualError#config_path and config_line to tool_file_path and tool_file_line
 *  ADDED: Allow a custom source list to be passed to StandardCLI
 *  ADDED: Support `--path` and `--git` flags in `toys do`
 *  ADDED: Add SourceSpec, an unresolved description of a tool source
 *  ADDED: Ensure a context directory is always available
 *  ADDED: Improvements to error rendering in the standard error handler
 *  FIXED: Various minor fixes
 *  FIXED: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
 *  DOCS: Fixed a few links in the reference documentation
 *  DOCS: Fix typos in the flag parsing directive documentation
 *  DOCS: Classes from toys-core display their notice at the end instead of the beginning of their description

----

## toys-core

 *  BREAKING CHANGE: Refactor CLI to extract a Runnable class and limit back-references to CLI
 *  BREAKING CHANGE: Extract tool name splitting from Loader into a public ToolNameSplitter class
 *  BREAKING CHANGE: Split SourceListBuilder out of Loader
 *  BREAKING CHANGE: Ensure a context directory is always available
 *  BREAKING CHANGE: Improvements to error rendering in the standard error handler
 *  BREAKING CHANGE: Replace SourceInfo's flat git and gem fields with an origin object
 *  BREAKING CHANGE: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
 *  ADDED: Add treat_unknown_flags_as_args directive
 *  ADDED: CLI#child can copy loader sources
 *  ADDED: Added CLI#add_config_gem and CLI#add_config_git
 *  ADDED: Add --gem flag to the do builtin
 *  ADDED: ToolDefinition#run_handler returns the delegate target for a delegating tool
 *  ADDED: Context keys and sentinels now display their names in diagnostic output
 *  ADDED: Extract tool name splitting from Loader into a public ToolNameSplitter class
 *  ADDED: Rename ContextualError#config_path and config_line to tool_file_path and tool_file_line
 *  ADDED: Replace SourceListBuilder with SourceList that is passed directly to the Loader
 *  ADDED: Add SourceSpec, an unresolved description of a tool source
 *  ADDED: Ensure a context directory is always available
 *  ADDED: The ApplyConfig middleware can now be provided independently in addition to from an existing source
 *  ADDED: Improvements to error rendering in the standard error handler
 *  ADDED: Replace SourceInfo's flat git and gem fields with an origin object
 *  FIXED: Fixed a "circular causes" error on certain versions of JRuby
 *  FIXED: Loader#add_path_set raises immediately for a relative path that is not a readable config
 *  FIXED: More minor loader cleanup
 *  FIXED: Identify flags by definition rather than by context key when validating flag groups
 *  FIXED: Include git_cache 0.1.2 which includes a fix for git auto maintenance races
 *  FIXED: Toys::Tool subclasses now have their own source info
 *  FIXED: Raise ToolDefinitionError when attempting to reset a tool previously defined by subclassing Toys::Tool
 *  FIXED: Preserve dependency provenance and require: in the modified gemfile
 *  FIXED: Honor BUNDLE_LOCKFILE and stop leaking it from the modified bundle
 *  FIXED: Various minor fixes
 *  FIXED: Raise ToolDefinitionError when attempting to create or descend into a subtool from within a subtool_apply block or middleware-based config
 *  DOCS: Fixed a few links in the reference documentation
 *  DOCS: Fix typos in the flag parsing directive documentation
 *  DOCS: Classify Middleware in the support layer
 *  DOCS: Update ToolDefinition docs with a note about the two-phase lifecycle

----

## toys-ci

 *  ADDED: Add SourceSpec, an unresolved description of a tool source

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys": null,
    "toys-core": null,
    "toys-ci": null,
    "toys-release": null,
    "common-tools": null
  },
  "request_sha": "7dcc296c8015252355fb5c397bb1d3a8c3637d70"
}
```
