### PR TITLE
release: Release 2 items

### DIFF
--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ### v0.24.0 / 2026-09-11
 
-* BREAKING CHANGE: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
-* BREAKING CHANGE: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
-* BREAKING CHANGE: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
-* ADDED: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
-* ADDED: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
-* ADDED: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
-* ADDED: SourceSpec::Gem now includes optional on_missing: and default_confirm: fields to control how missing gems are handled
-* ADDED: The load_gem directive now takes optional on_missing: and default_confirm: arguments to control how missing gems are handled
-* FIXED: Passing options when activating a gem using the `:gems` mixin no longer clobbers options passed when instantiating the mixin
+Feature updates:
+
+* `SourceSpec::Gem` now includes optional `on_missing:` and `default_confirm:` fields to control how missing gems are handled.
+* The `load_gem` directive now takes optional `on_missing:` and `default_confirm:` arguments to control how missing gems are handled.
+* Passing options when activating a gem using the `:gems` mixin no longer clobbers options passed when instantiating the mixin.
+
+Removed some old deprecated items. (All technically breaking changes)
+
+* Removed deprecated `Toys::CORE_VERSION`. Use `Toys::Core::VERSION` instead.
+* Removed deprecated `alias_tool` directive. Pass `delegate_relative:` to the `tool` directive instead.
+* Removed deprecated `suppress_confirm:` argument to the `Gems` utility. Use `on_missing:` instead.
 
 ### v0.23.0 / 2026-09-09
 

--- a/toys-core/CHANGELOG.md
+++ b/toys-core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+### v0.24.0 / 2026-09-11
+
+* BREAKING CHANGE: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
+* BREAKING CHANGE: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
+* BREAKING CHANGE: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
+* ADDED: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
+* ADDED: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
+* ADDED: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
+* ADDED: SourceSpec::Gem now includes optional on_missing: and default_confirm: fields to control how missing gems are handled
+* ADDED: The load_gem directive now takes optional on_missing: and default_confirm: arguments to control how missing gems are handled
+* FIXED: Passing options when activating a gem using the `:gems` mixin no longer clobbers options passed when instantiating the mixin
+
 ### v0.23.0 / 2026-09-09
 
 This is a major release, with several new features, a number of fixes, and a significant refactor of the tool loading and execution layers, including several breaking interface changes. It is a release candidate for the upcoming version 1.0.

--- a/toys-core/lib/toys/core.rb
+++ b/toys-core/lib/toys/core.rb
@@ -9,6 +9,6 @@ module Toys
     # Current version of Toys core.
     # @return [String]
     #
-    VERSION = "0.23.0"
+    VERSION = "0.24.0"
   end
 end

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ### v0.24.0 / 2026-09-11
 
-* BREAKING CHANGE: Removed deprecated gem_version argument from rspec and minitest templates
-* ADDED: Removed deprecated gem_version argument from rspec and minitest templates
-* ADDED: The `toys do` builtin provides an --on-missing-gem flag that governs how the --gem flag handles gems that are not installed
+* Feature: The `toys do` builtin provides an `--on-missing-gem` flag that governs how the `--gem` flag handles gems that are not installed.
+* BREAKING CHANGE: Removed deprecated `gem_version:` argument from `:rspec` and `:minitest` templates.
 
 ### v0.23.0 / 2026-09-09
 

--- a/toys/CHANGELOG.md
+++ b/toys/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### v0.24.0 / 2026-09-11
+
+* BREAKING CHANGE: Removed deprecated gem_version argument from rspec and minitest templates
+* ADDED: Removed deprecated gem_version argument from rspec and minitest templates
+* ADDED: The `toys do` builtin provides an --on-missing-gem flag that governs how the --gem flag handles gems that are not installed
+
 ### v0.23.0 / 2026-09-09
 
 This is a major release, with several new features. It also includes a significant refactor of some of the underlying layers, which should be mostly invisible. It is a release candidate for the upcoming version 1.0.

--- a/toys/lib/toys/version.rb
+++ b/toys/lib/toys/version.rb
@@ -5,5 +5,5 @@ module Toys
   # Current version of the Toys command line executable.
   # @return [String]
   #
-  VERSION = "0.23.0"
+  VERSION = "0.24.0"
 end


### PR DESCRIPTION
This pull request prepares new releases for the following components:

 *  **toys 0.24.0** (was 0.23.0)
 *  **toys-core 0.24.0** (was 0.23.0)

For each releasable component, this pull request modifies the version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

 *  To confirm this release, merge this pull request, ensuring the "release: pending" label is set. The release script will trigger automatically on merge.
 *  To abort this release, close this pull request without merging.

The generated changelog entries have been copied below:

----

## toys

 *  BREAKING CHANGE: Removed deprecated gem_version argument from rspec and minitest templates
 *  ADDED: Removed deprecated gem_version argument from rspec and minitest templates
 *  ADDED: The `toys do` builtin provides an --on-missing-gem flag that governs how the --gem flag handles gems that are not installed

----

## toys-core

 *  BREAKING CHANGE: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
 *  BREAKING CHANGE: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
 *  BREAKING CHANGE: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
 *  ADDED: Removed deprecated Toys::CORE_VERSION. Use Toys::Core::VERSION instead.
 *  ADDED: Removed deprecated alias_tool directive. Pass delegate_relative to the tool directive instead.
 *  ADDED: Removed deprecated suppress_confirm argument to the Gems utility. Use on_missing instead.
 *  ADDED: SourceSpec::Gem now includes optional on_missing: and default_confirm: fields to control how missing gems are handled
 *  ADDED: The load_gem directive now takes optional on_missing: and default_confirm: arguments to control how missing gems are handled
 *  FIXED: Passing options when activating a gem using the `:gems` mixin no longer clobbers options passed when instantiating the mixin

----

```
# release_metadata DO NOT REMOVE OR MODIFY
{
  "requested_components": {
    "toys": null,
    "toys-core": null
  },
  "request_sha": "d6a04cbb566f9433e033b36c4c243d06e0c1c855"
}
```
